### PR TITLE
Add progress tracking, database, and Gemini summaries

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,175 +1,96 @@
-from __future__ import annotations
+"""SQLite helpers for tracking Hollow Knight progress."""
+
 import os
+import sqlite3
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
-from sqlalchemy import (
-    create_engine,
-    String,
-    DateTime,
-    BigInteger,
-    Integer,
-    select,
-    Index,
-)
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, Session
+DB_PATH = os.getenv("DATABASE_PATH", "bot.sqlite3")
+_conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+_conn.row_factory = sqlite3.Row
 
-
-# Default database URL. Uses SQLite locally unless DATABASE_URL is set (e.g. to a Postgres connection string).
-DEFAULT_DB_URL = os.getenv("DATABASE_URL", "sqlite:///data.sqlite")
-
-
-class Base(DeclarativeBase):
-    """Base class for SQLAlchemy ORM models."""
-    pass
-
-
-class UserProgress(Base):
-    """Table tracking progress updates per guild and user."""
-
-    __tablename__ = "user_progress"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    guild_id: Mapped[int] = mapped_column(BigInteger, index=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, index=True)
-    content: Mapped[str] = mapped_column(String(2000))
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
-
-
-# Composite index to efficiently retrieve latest entries per guild
-Index(
-    "idx_progress_guild_time",
-    UserProgress.guild_id,
-    UserProgress.created_at.desc(),
-)
-
-
-class GuildSettings(Base):
-    """Persistent per-guild settings for reminders and scheduling."""
-
-    __tablename__ = "guild_settings"
-    guild_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    reminder_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
-    reminder_utc_time: Mapped[Optional[str]] = mapped_column(
-        String(5), nullable=True
-    )  # Format "HH:MM" in 24h UTC
-    last_summary_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True
+with _conn:
+    _conn.execute(
+        """CREATE TABLE IF NOT EXISTS progress (
+                guild_id TEXT,
+                user_id TEXT,
+                update TEXT,
+                ts INTEGER
+            )"""
+    )
+    _conn.execute(
+        """CREATE TABLE IF NOT EXISTS guild_config (
+                guild_id TEXT PRIMARY KEY,
+                recap_channel_id TEXT,
+                recap_time_utc TEXT
+            )"""
+    )
+    _conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_progress ON progress (guild_id, user_id, ts)"""
     )
 
 
-class Database:
-    """Data access layer encapsulating engine and sessions."""
-
-    def __init__(self, url: str = DEFAULT_DB_URL) -> None:
-        # SQLite requires check_same_thread=False for multi-threaded access.
-        connect_args: dict[str, bool] = (
-            {"check_same_thread": False} if url.startswith("sqlite") else {}
+def add_update(guild_id: int, user_id: int, text: str, ts: int) -> None:
+    """Store a progress update."""
+    with _conn:
+        _conn.execute(
+            "INSERT INTO progress (guild_id, user_id, update, ts) VALUES (?, ?, ?, ?)",
+            (str(guild_id), str(user_id), text, ts),
         )
-        self.engine = create_engine(
-            url, future=True, echo=False, connect_args=connect_args
+
+
+def get_last_update(guild_id: int, user_id: int) -> Optional[Tuple[str, int]]:
+    """Return the most recent update for a user in a guild."""
+    cur = _conn.execute(
+        "SELECT update, ts FROM progress WHERE guild_id=? AND user_id=? ORDER BY ts DESC LIMIT 1",
+        (str(guild_id), str(user_id)),
+    )
+    row = cur.fetchone()
+    return (row["update"], row["ts"]) if row else None
+
+
+def get_updates_today_by_guild(guild_id: int) -> Dict[str, List[str]]:
+    """Return today's updates grouped by user id."""
+    start_of_day = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    start_ts = int(start_of_day.timestamp())
+    cur = _conn.execute(
+        "SELECT user_id, update FROM progress WHERE guild_id=? AND ts>=? ORDER BY ts",
+        (str(guild_id), start_ts),
+    )
+    updates: Dict[str, List[str]] = {}
+    for row in cur.fetchall():
+        updates.setdefault(row["user_id"], []).append(row["update"])
+    return updates
+
+
+def set_recap_channel(guild_id: int, channel_id: int) -> None:
+    """Persist the channel to post recaps in."""
+    with _conn:
+        _conn.execute(
+            "INSERT INTO guild_config (guild_id, recap_channel_id) VALUES (?, ?)"
+            " ON CONFLICT(guild_id) DO UPDATE SET recap_channel_id=excluded.recap_channel_id",
+            (str(guild_id), str(channel_id)),
         )
-        Base.metadata.create_all(self.engine)
 
-    def add_progress(self, guild_id: int, user_id: int, content: str) -> None:
-        """Insert a progress update."""
-        now = datetime.now(timezone.utc)
-        with Session(self.engine) as session:
-            session.add(
-                UserProgress(
-                    guild_id=guild_id,
-                    user_id=user_id,
-                    content=content,
-                    created_at=now,
-                )
-            )
-            session.commit()
 
-    def get_last_progress(
-        self, guild_id: int, user_id: int
-    ) -> Optional[Tuple[str, datetime]]:
-        """Return the most recent progress entry for a given user in a guild."""
-        with Session(self.engine) as session:
-            stmt = (
-                select(UserProgress.content, UserProgress.created_at)
-                .where(
-                    (UserProgress.guild_id == guild_id)
-                    & (UserProgress.user_id == user_id)
-                )
-                .order_by(UserProgress.created_at.desc())
-                .limit(1)
-            )
-            row = session.execute(stmt).first()
-            return (row[0], row[1]) if row else None
+def set_recap_time(guild_id: int, hhmm: str) -> None:
+    """Persist the UTC time for daily recaps (format HH:MM)."""
+    with _conn:
+        _conn.execute(
+            "INSERT INTO guild_config (guild_id, recap_time_utc) VALUES (?, ?)"
+            " ON CONFLICT(guild_id) DO UPDATE SET recap_time_utc=excluded.recap_time_utc",
+            (str(guild_id), hhmm),
+        )
 
-    def get_updates_since(
-        self, guild_id: int, since: datetime
-    ) -> Dict[int, List[str]]:
-        """Return all updates since a given time keyed by user ID."""
-        with Session(self.engine) as session:
-            stmt = (
-                select(UserProgress.user_id, UserProgress.content)
-                .where(
-                    (UserProgress.guild_id == guild_id)
-                    & (UserProgress.created_at >= since)
-                )
-                .order_by(UserProgress.user_id, UserProgress.created_at.asc())
-            )
-            result: Dict[int, List[str]] = {}
-            for user_id, content in session.execute(stmt).all():
-                result.setdefault(user_id, []).append(content)
-            return result
 
-    def upsert_channel(self, guild_id: int, channel_id: int) -> None:
-        """Set or update the reminder channel for a guild."""
-        with Session(self.engine) as session:
-            settings = session.get(GuildSettings, guild_id)
-            if settings is None:
-                settings = GuildSettings(
-                    guild_id=guild_id, reminder_channel_id=channel_id
-                )
-                session.add(settings)
-            else:
-                settings.reminder_channel_id = channel_id
-            session.commit()
-
-    def set_schedule(self, guild_id: int, hhmm_utc: str) -> None:
-        """Set the daily reminder time for a guild (UTC)."""
-        with Session(self.engine) as session:
-            settings = session.get(GuildSettings, guild_id)
-            if settings is None:
-                settings = GuildSettings(
-                    guild_id=guild_id, reminder_utc_time=hhmm_utc
-                )
-                session.add(settings)
-            else:
-                settings.reminder_utc_time = hhmm_utc
-            session.commit()
-
-    def get_settings(self, guild_id: int) -> GuildSettings:
-        """Return guild settings, creating defaults if necessary."""
-        with Session(self.engine) as session:
-            settings = session.get(GuildSettings, guild_id)
-            if settings is None:
-                settings = GuildSettings(guild_id=guild_id)
-                session.add(settings)
-                session.commit()
-                session.refresh(settings)
-            return settings
-
-    def all_schedules(self) -> List[GuildSettings]:
-        """Return all guild settings with a scheduled time set."""
-        with Session(self.engine) as session:
-            stmt = select(GuildSettings).where(
-                GuildSettings.reminder_utc_time.is_not(None)
-            )
-            return [row[0] for row in session.execute(stmt).all()]
-
-    def mark_summary_sent(self, guild_id: int) -> None:
-        """Record that today's summary has been sent for the guild."""
-        with Session(self.engine) as session:
-            settings = session.get(GuildSettings, guild_id)
-            if settings is None:
-                settings = GuildSettings(guild_id=guild_id)
-                session.add(settings)
-            settings.last_summary_at = datetime.now(timezone.utc)
-            session.commit()
+def get_all_guild_configs() -> List[Tuple[str, Optional[str], Optional[str]]]:
+    """Return all guild configs."""
+    cur = _conn.execute(
+        "SELECT guild_id, recap_channel_id, recap_time_utc FROM guild_config"
+    )
+    return [
+        (row["guild_id"], row["recap_channel_id"], row["recap_time_utc"])
+        for row in cur.fetchall()
+    ]

--- a/gemini_integration.py
+++ b/gemini_integration.py
@@ -1,55 +1,53 @@
-"""Integration with Google's Gemini GenAI model for generating daily recaps."""
+"""Gemini model helpers for Hollow Knight bot."""
 
 import os
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from google import genai
 
-
-# The environment variable GEMINI_MODEL allows overriding the default model name.
-MODEL_NAME = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")
-
-# The client reads the API key from GEMINI_API_KEY or GOOGLE_API_KEY env var automatically.
 _client = genai.Client()
+DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")
 
 
-def _format_prompt(
-    server_name: str, date_str: str, updates_by_user: Dict[str, List[str]]
-) -> str:
-    """Construct a playful prompt summarizing the day's progress updates."""
-    lines: List[str] = [
-        "You are 'The Chronicler of Hallownest' writing a short, hype recap.",
-        f"Server: {server_name}",
-        f"Date (UTC): {date_str}",
-        "Write 5–10 sentences max. Make it playful, in-universe, PG-13, and avoid insults.",
-        "Mention players by their display names and summarize what each did.",
-        "Then end with a one-line rallying cry.",
-        "",
-        "RAW UPDATES:",
-    ]
-    for user, items in updates_by_user.items():
-        for item in items:
-            lines.append(f"- {user}: {item}")
-    return "\n".join(lines)
+def generate_daily_summary(server_name: str, updates_by_user: Dict[str, List[str]]) -> str:
+    """Ask Gemini to draft a playful daily recap.
 
+    Args:
+        server_name: Discord server name.
+        updates_by_user: Mapping of user display names to their raw updates.
 
-def generate_daily_summary(
-    server_name: str, updates_by_user: Dict[str, List[str]]
-) -> str:
-    """Generate a daily recap using the Gemini model.
-
-    If there are no updates, returns a quiet response. Otherwise constructs a prompt
-    and sends it to the Gemini API.
+    Returns:
+        Gemini's text response or a gentle fallback line.
     """
     if not updates_by_user:
         return "The caverns are quiet today. No new echoes stir in Hallownest."
+
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    prompt = _format_prompt(server_name, date_str, updates_by_user)
-    response = _client.models.generate_content(
-        model=MODEL_NAME,
-        contents=prompt,
-    )
-    # The SDK returns a TextResult; extract text and ensure fallback.
-    text = (response.text or "").strip()
-    return text or "The Chronicler fell silent. Try again later."
+    lines: List[str] = [
+        f"Server: {server_name}",
+        f"Date (UTC): {date_str}",
+        "Style: playful, in-universe, PG-13, no insults.",
+        "",
+        "RAW UPDATES:",
+    ]
+    for user, updates in updates_by_user.items():
+        for update in updates:
+            lines.append(f"- {user}: {update}")
+    prompt = "\n".join(lines)
+
+    try:
+        resp = _client.models.generate_content(model=DEFAULT_MODEL, contents=prompt)
+        return (resp.text or "").strip() or "The Chronicler fell silent. Try again later."
+    except Exception:
+        return "The Chronicler met a Shade while scribing. Later."
+
+
+def generate_reply(prompt: str, model: Optional[str] = None) -> str:
+    """Return a quick snarky reply from Gemini."""
+    model = model or DEFAULT_MODEL
+    try:
+        resp = _client.models.generate_content(model=model, contents=prompt)
+        return (resp.text or "").strip() or "Noted."
+    except Exception:
+        return "Noted."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 discord.py>=2.4,<3
 google-genai>=1.0.0
-SQLAlchemy>=2.0
-psycopg2-binary>=2.9


### PR DESCRIPTION
## Summary
- centralize Gemini model helpers for daily summaries and snarky replies
- replace SQLAlchemy with lightweight SQLite helpers for progress and config
- implement Discord bot commands, ambient progress logging, and daily recap loop
- add /hollow-bot slash commands and mention replies that use all logged updates as context

## Testing
- `python -m py_compile gemini_integration.py database.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf5b35a8b8832190d5e21d984a3cbf