### PR TITLE
Add LangChain conversation memory

### DIFF
--- a/langchain/__init__.py
+++ b/langchain/__init__.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Utility module providing a LangChain conversation chain for HollowBot."""
+
+import importlib
+import os
+import sys
+from typing import Any, List, Optional
+
+from gemini_integration import generate_reply
+
+
+def _external_import(name: str):
+    """Import module from installed ``langchain`` package.
+
+    The repository also provides a local ``langchain`` package containing this
+    file. To access the real LangChain library without name collisions we
+    temporarily remove the repo root from ``sys.path`` and clear our package from
+    ``sys.modules`` while importing.
+    """
+
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    removed_path = False
+    if repo_root in sys.path:
+        sys.path.remove(repo_root)
+        removed_path = True
+    saved_pkg = sys.modules.pop("langchain", None)
+    try:
+        return importlib.import_module(name)
+    finally:
+        if saved_pkg is not None:
+            sys.modules["langchain"] = saved_pkg
+        elif "langchain" in sys.modules:
+            del sys.modules["langchain"]
+        if removed_path:
+            sys.path.insert(0, repo_root)
+
+
+# Fetch classes from the real LangChain distribution.
+ConversationChain = _external_import("langchain.chains").ConversationChain
+ConversationBufferMemory = _external_import("langchain.memory").ConversationBufferMemory
+LLM = _external_import("langchain.llms.base").LLM
+
+
+class GeminiLLM(LLM):
+    """Minimal LLM wrapper that routes prompts to ``generate_reply``."""
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> str:
+        return generate_reply(prompt)
+
+    @property
+    def _llm_type(self) -> str:  # pragma: no cover - simple property
+        return "gemini"
+
+
+def build_chain() -> ConversationChain:
+    """Return a conversation chain with persona seeded memory."""
+
+    memory = ConversationBufferMemory()
+    memory.chat_memory.add_ai_message(
+        (
+            "I am HollowBot, chronicler of Hallownest. I speak in a whimsical, "
+            "in-universe tone, offering knowledge of the Hollow Knight world."
+        )
+    )
+    return ConversationChain(llm=GeminiLLM(), memory=memory)
+
+
+# Default chain instance used by the bot.
+chain = build_chain()
+
+__all__ = ["chain", "build_chain", "GeminiLLM"]

--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ from discord import app_commands
 from discord.ext import commands, tasks
 
 import database
-from gemini_integration import generate_daily_summary, generate_reply
+from gemini_integration import generate_daily_summary
+from langchain import chain as convo_chain
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("hollowbot")
@@ -57,7 +58,9 @@ def _build_updates_context(guild: discord.Guild) -> str:
 
 def _build_progress_reply(guild: discord.Guild, text: str) -> str:
     context = _build_updates_context(guild)
-    riff = generate_reply(f"Recent updates:\n{context}\nNew update: {text}")
+    riff = convo_chain.predict(
+        input=f"Recent updates:\n{context}\nNew update: {text}"
+    )
     reply = f"Noted: {text}"
     if riff and riff != "Noted.":
         reply += f"\n{riff}"
@@ -90,7 +93,7 @@ async def on_message(message: discord.Message) -> None:
 
     context = _build_updates_context(message.guild)
     prompt = f"Recent updates:\n{context}\nUser said: {rest}"
-    reply = generate_reply(prompt)
+    reply = convo_chain.predict(input=prompt)
     await message.reply(reply or "Noted.")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 discord.py>=2.4,<3
 google-genai>=1.0.0
+langchain
+langchain-community


### PR DESCRIPTION
## Summary
- add langchain and langchain-community dependencies
- provide a ConversationChain seeded with Hollow Knight persona memory
- route bot replies through the LangChain conversation chain

## Testing
- `python -m pytest -q`
- `python -m py_compile main.py langchain/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf67be8d948321a700758d28c716dc