### PR TITLE
feat: enable spontaneous chat replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Discord bot that tracks Hollow Knight progress and provides daily recaps with 
 - **Progress Tracking**: Record and track Hollow Knight achievements
 - **Daily Recaps**: AI-generated daily summaries with Hollow Knight lore and gaming memes
 - **Character Consistency**: Maintains authentic gamer Hollow Knight personality
+- **Spontaneous Chat**: Occasionally replies to regular channel messages
 - **Robust Error Handling**: Graceful failure handling with in-character responses
 - **Input Validation**: Comprehensive validation and sanitization
 - **Database Management**: SQLite-based progress storage with proper connection handling
@@ -57,10 +58,12 @@ pip install -r requirements.txt
 3. Set environment variables:
 ```bash
 export DISCORD_TOKEN="your_discord_bot_token"
-export GOOGLE_API_KEY="your_gemini_api_key"
+export GEMINI_API_KEY="your_gemini_api_key"
 export DATABASE_PATH="bot.sqlite3"  # Optional, defaults to bot.sqlite3
 export GEMINI_MODEL="gemini-2.0-flash"  # Optional, defaults to gemini-2.0-flash
 export LOG_LEVEL="INFO"  # Optional, defaults to INFO
+export COMMAND_PREFIX="!"  # Optional, defaults to "!"
+export SPONTANEOUS_RESPONSE_CHANCE="0.05"  # Optional, chance bot replies to any message (0-1)
 ```
 
 4. Run the bot:
@@ -75,12 +78,14 @@ The bot uses environment variables for configuration:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DISCORD_TOKEN` | Yes | - | Discord bot token |
-| `GOOGLE_API_KEY` | Yes | - | Google Gemini API key |
+| `GEMINI_API_KEY` | Yes | - | Google Gemini API key |
 | `DATABASE_PATH` | No | `bot.sqlite3` | SQLite database file path |
 | `GEMINI_MODEL` | No | `gemini-2.0-flash` | Gemini model to use |
 | `LOG_LEVEL` | No | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
+| `COMMAND_PREFIX` | No | `!` | Prefix for text commands |
 | `MAX_RETRIES` | No | `3` | Maximum retry attempts for API calls |
 | `REQUEST_TIMEOUT` | No | `30` | Request timeout in seconds |
+| `SPONTANEOUS_RESPONSE_CHANCE` | No | `0.05` | Chance the bot replies to any message |
 
 ## Commands
 

--- a/config.py
+++ b/config.py
@@ -2,11 +2,13 @@
 
 import os
 from dataclasses import dataclass
+
 from typing import Optional
 
 # Load .env file for local development
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
 except ImportError:
     # dotenv not installed, that's fine for production
@@ -16,35 +18,39 @@ except ImportError:
 @dataclass
 class BotConfig:
     """Bot configuration settings."""
-    
+
     # Required settings (no defaults)
     discord_token: str
     google_api_key: str
-    
+
     # Optional settings (with defaults)
-    command_prefix: Optional[str] = None
+    command_prefix: str = "!"
+    spontaneous_response_chance: float = 0.05
     database_path: str = "bot.sqlite3"
     database_url: Optional[str] = None  # PostgreSQL connection string
     gemini_model: str = "gemini-2.0-flash"
     log_level: str = "INFO"
     max_retries: int = 3
     request_timeout: int = 30
-    
+
     @classmethod
     def from_env(cls) -> "BotConfig":
         """Create configuration from environment variables."""
         discord_token = os.getenv("DISCORD_TOKEN")
         if not discord_token:
             raise ValueError("DISCORD_TOKEN environment variable is required")
-        
+
         google_api_key = os.getenv("GEMINI_API_KEY", "dummy-key-for-testing")
         if not google_api_key or google_api_key == "dummy-key-for-testing":
             print("WARNING: GEMINI_API_KEY not set, AI features will be limited")
-        
+
         return cls(
             discord_token=discord_token,
             google_api_key=google_api_key,
-            command_prefix=os.getenv("COMMAND_PREFIX"),
+            command_prefix=os.getenv("COMMAND_PREFIX", "!"),
+            spontaneous_response_chance=float(
+                os.getenv("SPONTANEOUS_RESPONSE_CHANCE", "0.05")
+            ),
             database_path=os.getenv("DATABASE_PATH", "bot.sqlite3"),
             database_url=os.getenv("DATABASE_URL"),  # PostgreSQL connection string
             gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.0-flash"),
@@ -52,25 +58,28 @@ class BotConfig:
             max_retries=int(os.getenv("MAX_RETRIES", "3")),
             request_timeout=int(os.getenv("REQUEST_TIMEOUT", "30")),
         )
-    
+
     def validate(self) -> None:
         """Validate configuration values."""
         if not self.discord_token:
             raise ValueError("Discord token is required")
-        
+
         # Only validate API key if it's not a dummy key
         if not self.google_api_key or self.google_api_key == "dummy-key-for-testing":
             print("WARNING: GEMINI_API_KEY not set, AI features will be limited")
-        
+
         if self.max_retries < 1:
             raise ValueError("max_retries must be at least 1")
-        
+
         if self.request_timeout < 1:
             raise ValueError("request_timeout must be at least 1")
-        
+
         valid_log_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
         if self.log_level.upper() not in valid_log_levels:
             raise ValueError(f"log_level must be one of {valid_log_levels}")
+
+        if not (0 <= self.spontaneous_response_chance <= 1):
+            raise ValueError("spontaneous_response_chance must be between 0 and 1")
 
 
 # Global configuration instance

--- a/main.py
+++ b/main.py
@@ -6,14 +6,16 @@
 # - Increment minor version (1.x -> 2.0) for major new features or breaking changes
 # - This version is used in /hollow-bot info command and health check endpoint
 # Bot version - increment this for each release
-BOT_VERSION = "1.4.2"
+BOT_VERSION = "1.4.5"
 
 import asyncio
+import os
+import random
 import re
 import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
-import os
+
 import pytz
 
 import discord
@@ -32,14 +34,14 @@ from logger import log
 
 class GeminiLLM(LLM):
     """Simple LLM wrapper for Gemini."""
-    
+
     def _call(self, prompt: str, **kwargs) -> str:
         try:
             return generate_reply(prompt)
         except Exception as e:
             log.error(f"GeminiLLM error: {e}")
             return "The Infection got to my response system. But I noted that, don't worry."
-    
+
     @property
     def _llm_type(self) -> str:
         return "gemini"
@@ -76,6 +78,7 @@ bot = commands.Bot(command_prefix=config.command_prefix, intents=intents)
 
 PROGRESS_RE = re.compile(r"\b(beat|got|found|upgraded)\b", re.I)
 last_sent: Dict[str, datetime.date] = {}
+SPONTANEOUS_RESPONSE_CHANCE = config.spontaneous_response_chance
 
 
 def is_admin(member: discord.Member) -> bool:
@@ -89,7 +92,7 @@ def _build_updates_context(guild: discord.Guild) -> str:
         validate_guild_id(guild.id)
         updates = database.get_updates_today_by_guild(guild.id)
         validated_updates = validate_updates_dict(updates)
-        
+
         lines: List[str] = []
         for uid, texts in validated_updates.items():
             try:
@@ -99,7 +102,7 @@ def _build_updates_context(guild: discord.Guild) -> str:
             except (ValueError, TypeError) as e:
                 log.warning(f"Invalid user ID in updates: {uid}, error: {e}")
                 continue
-        
+
         return "\n".join(lines) if lines else "No updates yet today."
     except (ValidationError, database.DatabaseError) as e:
         log.error(f"Failed to build updates context: {e}")
@@ -111,15 +114,18 @@ def _build_progress_reply(guild: discord.Guild, text: str) -> str:
     try:
         validated_text = validate_progress_text(text)
         context = _build_updates_context(guild)
-        
+
         # Use direct AI call instead of conversation memory to avoid interference
         prompt = f"Recent updates:\n{context}\nNew update: {validated_text}\n\nGive a short, snarky gamer response (1-2 sentences max) about this progress update."
         riff = generate_reply(prompt)
-        
+
         reply = f"📝 Echo recorded: {validated_text}"
-        if riff and riff not in ["Noted.", "Noted, gamer. The echoes of Hallownest have been recorded."]:
+        if riff and riff not in [
+            "Noted.",
+            "Noted, gamer. The echoes of Hallownest have been recorded.",
+        ]:
             reply += f"\n\n{riff}"
-        
+
         return reply
     except ValidationError as e:
         log.warning(f"Invalid progress text: {e}")
@@ -144,170 +150,249 @@ async def on_ready() -> None:
 @bot.event
 async def on_message(message: discord.Message) -> None:
     """Handle incoming messages."""
+    if message.author.bot or not message.guild or not bot.user:
+        return
+
+    content = message.content.strip()
+    if not content:
+        return
+
     try:
-        if message.author.bot or not message.guild or not bot.user:
-            return
-        
-        # Only respond to @ mentions, not commands
-        if not message.mentions or bot.user not in message.mentions:
-            return
-        
-        # Extract the message content after the mention
-        content = message.content.strip()
-        # Remove the mention from the content
-        for mention in message.mentions:
-            content = content.replace(f"<@!{mention.id}>", "").replace(f"<@{mention.id}>", "")
-        content = content.strip()
-        
-        if not content:
-            await message.reply("Hey gamer! What's up? Ready to talk about your Hallownest journey?")
-            return
+        mentioned = bot.user in message.mentions
 
-        log.info("Mention from %s: %s", message.author.id, content)
+        if mentioned:
+            for mention in message.mentions:
+                content = content.replace(f"<@!{mention.id}>", "").replace(
+                    f"<@{mention.id}>", ""
+                )
+            content = content.strip()
 
-        # Check if it's a progress update
-        if PROGRESS_RE.search(content):
-            await handle_progress(message, content)
-            return
+            if not content:
+                await message.reply(
+                    "Hey gamer! What's up? Ready to talk about your Hallownest journey?"
+                )
+                return
 
-        # Regular chat response with user's progress context
-        guild_context = _build_updates_context(message.guild)
-        
-        # Get the user's specific progress history for more personalized responses
-        user_progress = database.get_last_update(message.guild.id, message.author.id)
-        user_context = ""
-        if user_progress:
-            text, ts = user_progress
-            age_sec = int(time.time()) - ts
-            days = age_sec // 86400
-            hours = age_sec // 3600
-            age_str = f"{days}d" if days else f"{hours}h"
-            user_context = f"\nYour last progress: \"{text}\" ({age_str} ago)"
-        
-        prompt = f"Recent updates from everyone:\n{guild_context}{user_context}\n\nUser said: {content}\n\nRespond as HollowBot, referencing their progress if relevant. Keep it short and gamer-like (1-2 sentences max)."
-        reply = convo_chain.predict(input=prompt)
-        await message.reply(reply or "The echoes of Hallownest have been heard, gamer.")
-        
+            log.info("Mention from %s: %s", message.author.id, content)
+
+            if PROGRESS_RE.search(content):
+                await handle_progress(message, content)
+                return
+
+            guild_context = _build_updates_context(message.guild)
+            user_progress = database.get_last_update(
+                message.guild.id, message.author.id
+            )
+            user_context = ""
+            if user_progress:
+                text, ts = user_progress
+                age_sec = int(time.time()) - ts
+                days = age_sec // 86400
+                hours = age_sec // 3600
+                age_str = f"{days}d" if days else f"{hours}h"
+                user_context = f'\nYour last progress: "{text}" ({age_str} ago)'
+
+            prompt = (
+                "Recent updates from everyone:\n"
+                f"{guild_context}{user_context}\n\nUser said: {content}\n\n"
+                "Respond as HollowBot, referencing their progress if relevant. "
+                "Keep it short and gamer-like (1-2 sentences max)."
+            )
+            reply = convo_chain.predict(input=prompt)
+            await message.reply(
+                reply or "The echoes of Hallownest have been heard, gamer."
+            )
+        else:
+            if random.random() < SPONTANEOUS_RESPONSE_CHANCE:
+                log.info("Spontaneous response triggered in guild %s", message.guild.id)
+                guild_context = _build_updates_context(message.guild)
+                prompt = (
+                    "Recent updates from everyone:\n"
+                    f"{guild_context}\n\nUser said: {content}\n\n"
+                    "Respond as HollowBot. Keep it short and gamer-like (1-2 sentences max)."
+                )
+                reply = convo_chain.predict(input=prompt)
+                if reply:
+                    await message.reply(reply)
+
+    except commands.CommandError as e:
+        # Ignore command-related errors and let default handlers deal with them
+        log.debug(f"Command error in on_message: {e}")
     except Exception as e:
         log.error(f"Error handling message: {e}")
-        try:
-            await message.reply("The Infection got to my response system. But I heard you, gamer!")
-        except Exception as reply_error:
-            log.error(f"Failed to send error reply: {reply_error}")
+        if bot.user in message.mentions:
+            try:
+                await message.reply(
+                    "The Infection got to my response system. But I heard you, gamer!"
+                )
+            except Exception as reply_error:
+                log.error(f"Failed to send error reply: {reply_error}")
+    finally:
+        await bot.process_commands(message)
 
 
 async def handle_progress(message: discord.Message, text: str) -> None:
     """Handle progress updates with validation and error handling."""
     try:
         if not text:
-            await message.reply("Gamer, you gotta tell me what you accomplished! Usage: @HollowBot progress <what you did>")
+            await message.reply(
+                "Gamer, you gotta tell me what you accomplished! Usage: @HollowBot progress <what you did>"
+            )
             return
-        
+
         # Validate inputs
         validate_guild_id(message.guild.id)
         validate_user_id(message.author.id)
         validated_text = validate_progress_text(text)
-        
+
         now_ts = int(time.time())
         last = database.get_last_update(message.guild.id, message.author.id)
         database.add_update(message.guild.id, message.author.id, validated_text, now_ts)
-        
+
         # Debug: Verify the update was added
-        log.info(f"Added progress for user {message.author.id} in guild {message.guild.id}: {validated_text}")
+        log.info(
+            f"Added progress for user {message.author.id} in guild {message.guild.id}: {validated_text}"
+        )
         verify = database.get_last_update(message.guild.id, message.author.id)
         log.info(f"Verification - last update: {verify}")
-        
+
         reply = _build_progress_reply(message.guild, validated_text)
         await message.reply(reply)
-        
+
         # Check for long absence
         if last:
             days = (now_ts - last[1]) // 86400
             if days > 30:
-                await message.channel.send("Bruh, you beat the Mantis Lords months ago and you're still here? That's some serious dedication to the grind, gamer. Respect.")
-                
+                await message.channel.send(
+                    "Bruh, you beat the Mantis Lords months ago and you're still here? That's some serious dedication to the grind, gamer. Respect."
+                )
+
     except ValidationError as e:
         log.warning(f"Validation error in handle_progress: {e}")
-        await message.reply("Gamer, that progress update seems corrupted by the Infection. Try again with a cleaner message!")
+        await message.reply(
+            "Gamer, that progress update seems corrupted by the Infection. Try again with a cleaner message!"
+        )
     except database.DatabaseError as e:
         log.error(f"Database error in handle_progress: {e}")
-        await message.reply("The echoes of Hallownest are having trouble reaching the chronicle. Try again later, gamer!")
+        await message.reply(
+            "The echoes of Hallownest are having trouble reaching the chronicle. Try again later, gamer!"
+        )
     except Exception as e:
         log.error(f"Unexpected error in handle_progress: {e}")
-        await message.reply("The Infection got to my progress tracking system. But I'll try to remember that, gamer!")
+        await message.reply(
+            "The Infection got to my progress tracking system. But I'll try to remember that, gamer!"
+        )
 
 
-hollow_group = app_commands.Group(name="hollow-bot", description="Chronicle your Hallownest journey with HollowBot")
+hollow_group = app_commands.Group(
+    name="hollow-bot", description="Chronicle your Hallownest journey with HollowBot"
+)
 
 
-@hollow_group.command(name="progress", description="Record your latest Hallownest achievement")
+@hollow_group.command(
+    name="progress", description="Record your latest Hallownest achievement"
+)
 async def slash_progress(interaction: discord.Interaction, text: str) -> None:
     """Handle slash command for progress updates."""
     try:
         if not interaction.guild:
             if not interaction.response.is_done():
-                await interaction.response.send_message("Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!", ephemeral=True)
+                await interaction.response.send_message(
+                    "Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!",
+                    ephemeral=True,
+                )
             return
-        
+
         # Validate inputs
         validate_guild_id(interaction.guild.id)
         validate_user_id(interaction.user.id)
         validated_text = validate_progress_text(text)
-        
+
         now_ts = int(time.time())
         last = database.get_last_update(interaction.guild.id, interaction.user.id)
-        database.add_update(interaction.guild.id, interaction.user.id, validated_text, now_ts)
-        
+        database.add_update(
+            interaction.guild.id, interaction.user.id, validated_text, now_ts
+        )
+
         # Debug: Verify the update was added
-        log.info(f"Added progress for user {interaction.user.id} in guild {interaction.guild.id}: {validated_text}")
+        log.info(
+            f"Added progress for user {interaction.user.id} in guild {interaction.guild.id}: {validated_text}"
+        )
         verify = database.get_last_update(interaction.guild.id, interaction.user.id)
         log.info(f"Verification - last update: {verify}")
-        
+
         reply = _build_progress_reply(interaction.guild, validated_text)
-        
+
         if not interaction.response.is_done():
             await interaction.response.send_message(reply)
         else:
             await interaction.followup.send(reply)
-        
+
         # Check for long absence
         if last:
             days = (now_ts - last[1]) // 86400
             if days > 30 and interaction.channel:
-                await interaction.channel.send("Bruh, you beat the Mantis Lords months ago and you're still here? That's some serious dedication to the grind, gamer. Respect.")
-                
+                await interaction.channel.send(
+                    "Bruh, you beat the Mantis Lords months ago and you're still here? That's some serious dedication to the grind, gamer. Respect."
+                )
+
     except ValidationError as e:
         log.warning(f"Validation error in slash_progress: {e}")
         if not interaction.response.is_done():
-            await interaction.response.send_message("Gamer, that progress update seems corrupted by the Infection. Try again with a cleaner message!", ephemeral=True)
+            await interaction.response.send_message(
+                "Gamer, that progress update seems corrupted by the Infection. Try again with a cleaner message!",
+                ephemeral=True,
+            )
         else:
-            await interaction.followup.send("Gamer, that progress update seems corrupted by the Infection. Try again with a cleaner message!", ephemeral=True)
+            await interaction.followup.send(
+                "Gamer, that progress update seems corrupted by the Infection. Try again with a cleaner message!",
+                ephemeral=True,
+            )
     except database.DatabaseError as e:
         log.error(f"Database error in slash_progress: {e}")
         if not interaction.response.is_done():
-            await interaction.response.send_message("The echoes of Hallownest are having trouble reaching the chronicle. Try again later, gamer!", ephemeral=True)
+            await interaction.response.send_message(
+                "The echoes of Hallownest are having trouble reaching the chronicle. Try again later, gamer!",
+                ephemeral=True,
+            )
         else:
-            await interaction.followup.send("The echoes of Hallownest are having trouble reaching the chronicle. Try again later, gamer!", ephemeral=True)
+            await interaction.followup.send(
+                "The echoes of Hallownest are having trouble reaching the chronicle. Try again later, gamer!",
+                ephemeral=True,
+            )
     except Exception as e:
         log.error(f"Unexpected error in slash_progress: {e}")
         if not interaction.response.is_done():
-            await interaction.response.send_message("The Infection got to my progress tracking system. But I'll try to remember that, gamer!", ephemeral=True)
+            await interaction.response.send_message(
+                "The Infection got to my progress tracking system. But I'll try to remember that, gamer!",
+                ephemeral=True,
+            )
         else:
-            await interaction.followup.send("The Infection got to my progress tracking system. But I'll try to remember that, gamer!", ephemeral=True)
+            await interaction.followup.send(
+                "The Infection got to my progress tracking system. But I'll try to remember that, gamer!",
+                ephemeral=True,
+            )
 
 
-@hollow_group.command(name="get_progress", description="Check the latest echo from a gamer's journey")
+@hollow_group.command(
+    name="get_progress", description="Check the latest echo from a gamer's journey"
+)
 async def slash_get_progress(
     interaction: discord.Interaction, user: Optional[discord.Member] = None
 ) -> None:
     try:
         if not interaction.guild:
             if not interaction.response.is_done():
-                await interaction.response.send_message("Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!", ephemeral=True)
+                await interaction.response.send_message(
+                    "Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!",
+                    ephemeral=True,
+                )
             return
-        
+
         target = user or interaction.user
-        log.info(f"Getting progress for user {target.id} in guild {interaction.guild.id}")
+        log.info(
+            f"Getting progress for user {target.id} in guild {interaction.guild.id}"
+        )
         result = database.get_last_update(interaction.guild.id, target.id)
         log.info(f"Database returned: {result}")
         if not result:
@@ -320,50 +405,64 @@ async def slash_get_progress(
                     f"No echoes recorded for {target.display_name} yet. Time to start that Hallownest journey, gamer!"
                 )
             return
-        
+
         text, ts = result
         age_sec = int(time.time()) - ts
         days = age_sec // 86400
         hours = age_sec // 3600
         age_str = f"{days}d" if days else f"{hours}h"
-        
+
         if not interaction.response.is_done():
             await interaction.response.send_message(
-                f"📜 Last echo from **{target.display_name}**: \"{text}\" ({age_str} ago)"
+                f'📜 Last echo from **{target.display_name}**: "{text}" ({age_str} ago)'
             )
         else:
             await interaction.followup.send(
-                f"📜 Last echo from **{target.display_name}**: \"{text}\" ({age_str} ago)"
+                f'📜 Last echo from **{target.display_name}**: "{text}" ({age_str} ago)'
             )
     except Exception as e:
         log.error(f"Error in slash_get_progress: {e}")
         if not interaction.response.is_done():
-            await interaction.response.send_message("The Infection got to my memory system. Try again later, gamer!", ephemeral=True)
+            await interaction.response.send_message(
+                "The Infection got to my memory system. Try again later, gamer!",
+                ephemeral=True,
+            )
         else:
-            await interaction.followup.send("The Infection got to my memory system. Try again later, gamer!", ephemeral=True)
+            await interaction.followup.send(
+                "The Infection got to my memory system. Try again later, gamer!",
+                ephemeral=True,
+            )
 
 
-@hollow_group.command(name="set_reminder_channel", description="Set the chronicle channel for daily echoes")
+@hollow_group.command(
+    name="set_reminder_channel",
+    description="Set the chronicle channel for daily echoes",
+)
 async def slash_set_channel(interaction: discord.Interaction) -> None:
     try:
         if not interaction.guild or not interaction.channel:
             if not interaction.response.is_done():
-                await interaction.response.send_message("Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!", ephemeral=True)
+                await interaction.response.send_message(
+                    "Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!",
+                    ephemeral=True,
+                )
             return
-        
+
         if not is_admin(interaction.user):
             if not interaction.response.is_done():
                 await interaction.response.send_message(
-                    "Gamer, you need Manage Server permissions to set up the chronicle channel. The Infection won't let just anyone mess with the echoes.", ephemeral=True
+                    "Gamer, you need Manage Server permissions to set up the chronicle channel. The Infection won't let just anyone mess with the echoes.",
+                    ephemeral=True,
                 )
             else:
                 await interaction.followup.send(
-                    "Gamer, you need Manage Server permissions to set up the chronicle channel. The Infection won't let just anyone mess with the echoes.", ephemeral=True
+                    "Gamer, you need Manage Server permissions to set up the chronicle channel. The Infection won't let just anyone mess with the echoes.",
+                    ephemeral=True,
                 )
             return
-        
+
         database.set_recap_channel(interaction.guild.id, interaction.channel.id)
-        
+
         if not interaction.response.is_done():
             await interaction.response.send_message(
                 f"📜 Chronicle channel set to {interaction.channel.mention}. The echoes of Hallownest will be recorded here daily, gamer!"
@@ -375,9 +474,15 @@ async def slash_set_channel(interaction: discord.Interaction) -> None:
     except Exception as e:
         log.error(f"Error in slash_set_channel: {e}")
         if not interaction.response.is_done():
-            await interaction.response.send_message("The Infection got to my channel setup system. Try again later, gamer!", ephemeral=True)
+            await interaction.response.send_message(
+                "The Infection got to my channel setup system. Try again later, gamer!",
+                ephemeral=True,
+            )
         else:
-            await interaction.followup.send("The Infection got to my channel setup system. Try again later, gamer!", ephemeral=True)
+            await interaction.followup.send(
+                "The Infection got to my channel setup system. Try again later, gamer!",
+                ephemeral=True,
+            )
 
 
 @hollow_group.command(name="info", description="Get info about HollowBot")
@@ -396,7 +501,7 @@ async def slash_info(interaction: discord.Interaction) -> None:
             "**Chat:** Just @ me to talk! I remember our conversations and give gamer advice.\n\n"
             "Ready to chronicle your journey through Hallownest, gamer! 🗡️"
         )
-        
+
         if not interaction.response.is_done():
             await interaction.response.send_message(info_message)
         else:
@@ -404,48 +509,66 @@ async def slash_info(interaction: discord.Interaction) -> None:
     except Exception as e:
         log.error(f"Error in slash_info: {e}")
         if not interaction.response.is_done():
-            await interaction.response.send_message("The Infection got to my info system. Try again later, gamer!", ephemeral=True)
+            await interaction.response.send_message(
+                "The Infection got to my info system. Try again later, gamer!",
+                ephemeral=True,
+            )
         else:
-            await interaction.followup.send("The Infection got to my info system. Try again later, gamer!", ephemeral=True)
+            await interaction.followup.send(
+                "The Infection got to my info system. Try again later, gamer!",
+                ephemeral=True,
+            )
 
 
 @hollow_group.command(
-    name="schedule_daily_reminder", description="Schedule when the chronicle echoes daily"
+    name="schedule_daily_reminder",
+    description="Schedule when the chronicle echoes daily",
 )
-async def slash_schedule(interaction: discord.Interaction, time: str, timezone: str = "UTC") -> None:
+async def slash_schedule(
+    interaction: discord.Interaction, time: str, timezone: str = "UTC"
+) -> None:
     try:
         if not interaction.guild:
             if not interaction.response.is_done():
-                await interaction.response.send_message("Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!", ephemeral=True)
+                await interaction.response.send_message(
+                    "Gamer, this command only works in servers. The echoes of Hallownest need a proper gathering place!",
+                    ephemeral=True,
+                )
             return
-        
+
         if not is_admin(interaction.user):
             if not interaction.response.is_done():
                 await interaction.response.send_message(
-                    "Gamer, you need Manage Server permissions to schedule the chronicle. The Infection won't let just anyone mess with the echoes.", ephemeral=True
+                    "Gamer, you need Manage Server permissions to schedule the chronicle. The Infection won't let just anyone mess with the echoes.",
+                    ephemeral=True,
                 )
             else:
                 await interaction.followup.send(
-                    "Gamer, you need Manage Server permissions to schedule the chronicle. The Infection won't let just anyone mess with the echoes.", ephemeral=True
+                    "Gamer, you need Manage Server permissions to schedule the chronicle. The Infection won't let just anyone mess with the echoes.",
+                    ephemeral=True,
                 )
             return
-        
+
         try:
             validated_time = validate_time_format(time)
             validated_timezone = validate_timezone(timezone)
         except ValidationError as e:
             if not interaction.response.is_done():
                 await interaction.response.send_message(
-                    f"Gamer, {e}. Even the Pale King had better time management than that!", ephemeral=True
+                    f"Gamer, {e}. Even the Pale King had better time management than that!",
+                    ephemeral=True,
                 )
             else:
                 await interaction.followup.send(
-                    f"Gamer, {e}. Even the Pale King had better time management than that!", ephemeral=True
+                    f"Gamer, {e}. Even the Pale King had better time management than that!",
+                    ephemeral=True,
                 )
             return
-        
-        database.set_recap_time(interaction.guild.id, validated_time, validated_timezone)
-        
+
+        database.set_recap_time(
+            interaction.guild.id, validated_time, validated_timezone
+        )
+
         if not interaction.response.is_done():
             await interaction.response.send_message(
                 f"⏰ Chronicle scheduled for **{validated_time} {validated_timezone}**. The echoes of Hallownest will be chronicled daily at this time, gamer!"
@@ -457,9 +580,15 @@ async def slash_schedule(interaction: discord.Interaction, time: str, timezone: 
     except Exception as e:
         log.error(f"Error in slash_schedule: {e}")
         if not interaction.response.is_done():
-            await interaction.response.send_message("The Infection got to my scheduling system. Try again later, gamer!", ephemeral=True)
+            await interaction.response.send_message(
+                "The Infection got to my scheduling system. Try again later, gamer!",
+                ephemeral=True,
+            )
         else:
-            await interaction.followup.send("The Infection got to my scheduling system. Try again later, gamer!", ephemeral=True)
+            await interaction.followup.send(
+                "The Infection got to my scheduling system. Try again later, gamer!",
+                ephemeral=True,
+            )
 
 
 bot.tree.add_command(hollow_group)
@@ -471,18 +600,18 @@ async def recap_tick() -> None:
     try:
         if not bot.user:
             return
-        
+
         now = datetime.now(timezone.utc)
         hhmm = now.strftime("%H:%M")
-        
+
         guild_configs = database.get_all_guild_configs()
         log.debug(f"Checking {len(guild_configs)} guild configs for recap time {hhmm}")
-        
+
         for guild_id, channel_id, recap_time, timezone_str in guild_configs:
             try:
                 if not channel_id or not recap_time:
                     continue
-                
+
                 # Convert the scheduled time to the guild's timezone
                 try:
                     # Parse the timezone
@@ -493,48 +622,62 @@ async def recap_tick() -> None:
                         offset_str = timezone_str[3:]  # Remove "UTC"
                         if offset_str.startswith("+"):
                             offset_hours = int(offset_str[1:].split(":")[0])
-                            offset_minutes = int(offset_str.split(":")[1]) if ":" in offset_str else 0
+                            offset_minutes = (
+                                int(offset_str.split(":")[1])
+                                if ":" in offset_str
+                                else 0
+                            )
                         elif offset_str.startswith("-"):
                             offset_hours = -int(offset_str[1:].split(":")[0])
-                            offset_minutes = -int(offset_str.split(":")[1]) if ":" in offset_str else 0
+                            offset_minutes = (
+                                -int(offset_str.split(":")[1])
+                                if ":" in offset_str
+                                else 0
+                            )
                         else:
                             offset_hours = int(offset_str.split(":")[0])
-                            offset_minutes = int(offset_str.split(":")[1]) if ":" in offset_str else 0
-                        
+                            offset_minutes = (
+                                int(offset_str.split(":")[1])
+                                if ":" in offset_str
+                                else 0
+                            )
+
                         tz = pytz.FixedOffset(offset_hours * 60 + offset_minutes)
                     else:
                         # Try to get timezone by name (EST, PST, America/New_York, etc.)
                         tz = pytz.timezone(timezone_str)
-                    
+
                     # Get current time in the guild's timezone
                     now_in_tz = now.astimezone(tz)
                     current_time_str = now_in_tz.strftime("%H:%M")
-                    
+
                     # Check if it's time for the recap
                     if recap_time != current_time_str:
                         continue
-                        
+
                 except Exception as tz_error:
-                    log.warning(f"Invalid timezone {timezone_str} for guild {guild_id}: {tz_error}")
+                    log.warning(
+                        f"Invalid timezone {timezone_str} for guild {guild_id}: {tz_error}"
+                    )
                     # Fallback to UTC comparison
                     if recap_time != hhmm:
                         continue
-                
+
                 if last_sent.get(guild_id) == now.date():
                     continue
-                
+
                 # Get updates for this guild
                 updates = database.get_updates_today_by_guild(int(guild_id))
                 validated_updates = validate_updates_dict(updates)
-                
+
                 if not validated_updates:
                     log.debug(f"No updates to summarize for guild {guild_id}")
                     continue
-                
+
                 # Get guild info
                 guild = bot.get_guild(int(guild_id))
                 pretty: Dict[str, List[str]] = {}
-                
+
                 if guild:
                     server_name = validate_server_name(guild.name)
                     for uid, items in validated_updates.items():
@@ -545,37 +688,45 @@ async def recap_tick() -> None:
                                 try:
                                     member = await guild.fetch_member(int(uid))
                                 except discord.NotFound:
-                                    log.warning(f"Member {uid} not found in guild {guild_id}")
+                                    log.warning(
+                                        f"Member {uid} not found in guild {guild_id}"
+                                    )
                                     member = None
-                            
+
                             name = member.display_name if member else f"User {uid}"
                             pretty[name] = items
                         except (ValueError, TypeError) as e:
-                            log.warning(f"Invalid user ID in updates: {uid}, error: {e}")
+                            log.warning(
+                                f"Invalid user ID in updates: {uid}, error: {e}"
+                            )
                             continue
                 else:
                     server_name = f"Guild {guild_id}"
-                    pretty = {f"User {uid}": items for uid, items in validated_updates.items()}
-                
+                    pretty = {
+                        f"User {uid}": items for uid, items in validated_updates.items()
+                    }
+
                 # Generate and send summary
                 summary = generate_daily_summary(server_name, pretty)
-                
+
                 channel = bot.get_channel(int(channel_id))
                 if not channel:
                     try:
                         channel = await bot.fetch_channel(int(channel_id))
                     except discord.NotFound:
-                        log.error(f"Channel {channel_id} not found for guild {guild_id}")
+                        log.error(
+                            f"Channel {channel_id} not found for guild {guild_id}"
+                        )
                         continue
-                
+
                 await channel.send(summary)
                 last_sent[guild_id] = now.date()
                 log.info(f"Sent daily recap for guild {guild_id}")
-                
+
             except Exception as e:
                 log.error(f"Error processing recap for guild {guild_id}: {e}")
                 continue
-                
+
     except Exception as e:
         log.error(f"Error in recap_tick: {e}")
 
@@ -588,13 +739,13 @@ async def health_check(request):
 async def start_web_server():
     """Start a simple HTTP server for Render port binding."""
     app = web.Application()
-    app.router.add_get('/', health_check)
-    app.router.add_get('/health', health_check)
-    
-    port = int(os.environ.get('PORT', 8000))
+    app.router.add_get("/", health_check)
+    app.router.add_get("/health", health_check)
+
+    port = int(os.environ.get("PORT", 8000))
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, '0.0.0.0', port)
+    site = web.TCPSite(runner, "0.0.0.0", port)
     await site.start()
     log.info(f"HTTP server started on port {port}")
 
@@ -603,7 +754,7 @@ async def main():
     """Main function to start both the bot and web server."""
     # Start the web server in the background
     await start_web_server()
-    
+
     # Start the Discord bot
     try:
         log.info("Starting HollowBot...")


### PR DESCRIPTION
## Summary
- allow HollowBot to occasionally reply to ordinary channel messages
- make chance configurable via `SPONTANEOUS_RESPONSE_CHANCE`
- document spontaneous chat feature and config
- handle command errors gracefully so generic "Infection" replies aren't sent for every chat
- bump bot version to 1.4.5

## Testing
- `black .`
- `flake8 .` (fails: many style errors in config.py and other modules)
- `mypy .` (fails: missing psycopg2 stubs and type errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c063580a9c832190f70d5220118229