### PR TITLE
Add command for configuring random chatter chance

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The bot uses environment variables for configuration:
 
 - `/hollow-bot progress <text>`: Record your latest Hallownest achievement
 - `/hollow-bot get_progress [user]`: Check the latest echo from a gamer's journey
+- `/hollow-bot rando-talk <0-100>`: Set chance the bot replies to random messages
 - `/hollow-bot set_reminder_channel`: Set the chronicle channel for daily echoes
 - `/hollow-bot schedule_daily_reminder <time>`: Schedule when the chronicle echoes daily (UTC)
 


### PR DESCRIPTION
## Summary
- allow servers to set HollowBot's spontaneous chatter rate with `/hollow-bot rando-talk <0-100>`
- honour per-server settings when deciding whether to reply to regular messages
- document new command and bump bot version to 1.4.6

## Testing
- `DISCORD_TOKEN=dummy GEMINI_API_KEY=dummy python test_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a5afb8488321b612da0753135ab1