### PR TITLE
Add reflection-based random chatter and per-guild custom context

### DIFF
--- a/test_bot.py
+++ b/test_bot.py
@@ -76,15 +76,22 @@ def test_validation():
     print("\nTesting validation...")
     
     try:
-        from validation import validate_progress_text, validate_time_format
-        
+        from validation import (
+            validate_progress_text,
+            validate_time_format,
+            validate_custom_context,
+        )
+
         # Test valid inputs
         result = validate_progress_text("Beat the Mantis Lords!")
         print(f"✅ Valid progress text: {result}")
-        
+
         result = validate_time_format("18:30")
         print(f"✅ Valid time format: {result}")
-        
+
+        result = validate_custom_context("Speak like Zote")
+        print(f"✅ Valid custom context: {result}")
+
         # Test invalid inputs
         try:
             validate_progress_text("")
@@ -92,14 +99,21 @@ def test_validation():
             return False
         except:
             print("✅ Correctly rejected empty text")
-        
+
         try:
             validate_time_format("25:00")
             print("❌ Should have failed on invalid time")
             return False
         except:
             print("✅ Correctly rejected invalid time")
-        
+
+        try:
+            validate_custom_context("")
+            print("❌ Should have failed on empty context")
+            return False
+        except:
+            print("✅ Correctly rejected empty context")
+
         return True
     except Exception as e:
         print(f"❌ Validation test failed: {e}")

--- a/validation.py
+++ b/validation.py
@@ -158,3 +158,19 @@ def validate_updates_dict(updates_by_user: dict) -> dict:
             validated[user.strip()] = validated_updates
     
     return validated
+
+
+def validate_custom_context(text: str) -> str:
+    """Validate custom context text."""
+    if not isinstance(text, str):
+        raise ValidationError("Custom context must be a string")
+
+    text = text.strip()
+
+    if not text:
+        raise ValidationError("Custom context cannot be empty")
+
+    if len(text) > 1000:
+        raise ValidationError("Custom context is too long (max 1000 characters)")
+
+    return text


### PR DESCRIPTION
## Summary
- let HollowBot store per-guild custom context and expose `/hollow-bot custom-context`
- include custom context in replies and progress riffs
- make spontaneous chatter reflect on whether to respond using LLM

## Testing
- `DISCORD_TOKEN=dummy GEMINI_API_KEY=dummy-key-for-testing pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b6d0a0f88321a86a3a1e1fe6213c