### PR TITLE
Use LangChain agent for response decisions and rando-talk config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The bot uses environment variables for configuration:
 
 - `/hollow-bot progress <text>`: Record your latest Hallownest achievement
 - `/hollow-bot get_progress [user]`: Check the latest echo from a gamer's journey
-- `/hollow-bot rando-talk <0-100>`: Set chance the bot replies to random messages
+- `/hollow-bot rando-talk [0-100]`: View or set chance the bot replies to random messages
 - `/hollow-bot set_reminder_channel`: Set the chronicle channel for daily echoes
 - `/hollow-bot schedule_daily_reminder <time>`: Schedule when the chronicle echoes daily (UTC)
 

--- a/agents/response_decider.py
+++ b/agents/response_decider.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+from langchain.agents import AgentType, initialize_agent
+from langchain.memory import ConversationBufferMemory
+from langchain_core.language_models.llms import LLM
+
+from gemini_integration import generate_reply
+from logger import log
+
+
+class GeminiLLM(LLM):
+    """LangChain LLM wrapper that uses our Gemini integration."""
+
+    def _call(self, prompt: str, **kwargs: Optional[dict]) -> str:  # type: ignore[override]
+        try:
+            return generate_reply(prompt)
+        except Exception as e:  # pragma: no cover - network/LLM errors
+            log.error(f"GeminiLLM error: {e}")
+            return "no"
+
+    @property
+    def _llm_type(self) -> str:
+        return "gemini"
+
+
+# Persistent memory so the agent has context across decisions
+_memory = ConversationBufferMemory(memory_key="chat_history")
+_llm = GeminiLLM()
+_agent = initialize_agent(
+    tools=[],
+    llm=_llm,
+    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+    verbose=False,
+    memory=_memory,
+)
+
+
+def should_respond(
+    recent: str, guild_context: str, author: str, custom_context: str
+) -> bool:
+    """Use an LLM-powered agent to decide if the bot should reply."""
+    preamble = f"{custom_context}\n" if custom_context else ""
+    prompt = (
+        f"{preamble}Recent conversation:\n{recent}\n\n"
+        f"Recent updates from everyone:\n{guild_context}\n"
+        f"The last message was from {author}. Should HollowBot reply? Answer yes or no."
+    )
+    try:
+        decision = _agent.run(prompt).strip().lower()
+        return decision.startswith("y")
+    except Exception as e:  # pragma: no cover - LLM call failures
+        log.error(f"Response decider failed: {e}")
+        return False


### PR DESCRIPTION
## Summary
- add LangChain-based agent that judges recent chat and guild updates to decide if HollowBot should reply
- route `_should_respond` through the new agent
- allow `/hollow-bot rando-talk` to view or set the spontaneous response probability

## Testing
- `DISCORD_TOKEN=dummy GEMINI_API_KEY=dummy python test_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0c57179d88321851b23a7aedabc61