### PR TITLE
Scope memories per guild

### DIFF
--- a/agents/response_decider.py
+++ b/agents/response_decider.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from langchain.agents import AgentType, initialize_agent
-from langchain.memory import ConversationBufferMemory
 from langchain_core.language_models.llms import LLM
 
 from gemini_integration import generate_reply
@@ -23,15 +22,13 @@ class GeminiLLM(LLM):
         return "gemini"
 
 
-# Persistent memory so the agent has context across decisions
-_memory = ConversationBufferMemory(memory_key="chat_history")
+# Stateless agent for response decisions
 _llm = GeminiLLM()
 _agent = initialize_agent(
     tools=[],
     llm=_llm,
     agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
     verbose=False,
-    memory=_memory,
 )
 
 

--- a/gemini_integration.py
+++ b/gemini_integration.py
@@ -131,3 +131,17 @@ def generate_reply(
     except Exception as e:
         log.error(f"Failed to generate reply: {e}")
         return "The Infection got to my response system. But I noted that, don't worry."
+
+
+def generate_memory(text: str) -> str:
+    """Create a concise memory from a progress update."""
+    try:
+        prompt = (
+            "You are HollowBot. Given the following progress update, create a short memory to "
+            "remember about this server. Keep it under one sentence and avoid generic replies.\n"
+            f"Progress update: {text}\nMemory:"
+        )
+        return _gemini_client.generate_content(prompt)
+    except Exception as e:
+        log.error(f"Failed to generate memory: {e}")
+        return ""

--- a/test_bot.py
+++ b/test_bot.py
@@ -7,7 +7,10 @@ import sys
 def test_imports():
     """Test that all modules can be imported."""
     print("Testing imports...")
-    
+
+    os.environ["DISCORD_TOKEN"] = "dummy"
+    os.environ["GEMINI_API_KEY"] = "dummy"
+
     try:
         import config
         print("✅ config imported")
@@ -119,6 +122,22 @@ def test_validation():
         print(f"❌ Validation test failed: {e}")
         return False
 
+
+def test_memory_db():
+    """Test memory database operations."""
+    print("\nTesting memory DB...")
+    try:
+        import database
+
+        mem_id = database.add_memory(1, "Test memory")
+        memories = database.get_memories_by_guild(1)
+        assert any(mid == mem_id for mid, _ in memories)
+        database.delete_memory(1, mem_id)
+        print("✅ Memory DB functions")
+        return True
+    except Exception as e:
+        print(f"❌ Memory DB test failed: {e}")
+        return False
 def main():
     """Run all tests."""
     print("🧪 Hollow Knight Bot Test Suite")
@@ -128,6 +147,7 @@ def main():
         test_imports,
         test_config,
         test_validation,
+        test_memory_db,
     ]
     
     passed = 0


### PR DESCRIPTION
## Summary
- store per-guild memories in the database with CRUD helpers
- weave memories into prompts and generate them from progress updates
- add `/hollow-bot memory` commands and simplify response-decider to be stateless

## Testing
- `python test_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0c29b3d10832183e905deca73a509