### PR TITLE
fix: correct import path for AI analysis

### DIFF
--- a/src/save_parsing/save_parser.py
+++ b/src/save_parsing/save_parser.py
@@ -260,7 +260,7 @@ def format_save_summary(summary: Dict[str, Any]) -> str:
 def generate_save_analysis(summary: Dict[str, Any]) -> str:
     """Generate AI analysis of the save data."""
     try:
-        from gemini_integration import generate_reply
+        from ..ai.gemini_integration import generate_reply
         
         prompt = f"""You are HollowBot, a seasoned Hollow Knight player who's 112% the game. 
 Analyze this save data and give a short, personalized response (1-2 sentences max):


### PR DESCRIPTION
## Summary
- fix generate_save_analysis to import Gemini reply helper from the proper package

## Testing
- `pytest tests/test_save_parser.py::TestSaveAnalysis::test_fresh_save_analysis -q`
- `pytest tests/test_save_parser.py::TestSaveAnalysis::test_midgame_save_analysis -q`


------
https://chatgpt.com/codex/tasks/task_e_68c27648488c8321942cda9178590541