### PR TITLE
refactor: remove sys.path hacks and standardize package imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
-"""Hollow Knight Discord Bot - Main Entry Point"""
+"""Hollow Knight Discord Bot - Main entry point."""
 
-import sys
-import os
 import asyncio
 
-# Add src directory to Python path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
-
-# Import and run the main bot
 from src.core.main import main
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hollow-knight-bot"
+version = "0.1.0"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/ai/agents/response_decider.py
+++ b/src/ai/agents/response_decider.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from langchain_core.language_models.llms import LLM
 
-from ..gemini_integration import generate_reply
-from ...core.logger import log
+from ai.gemini_integration import generate_reply
+from core.logger import log
 
 
 class GeminiLLM(LLM):

--- a/src/ai/gemini_integration.py
+++ b/src/ai/gemini_integration.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Optional
 
 import google.generativeai as genai
 
-from ..core.config import config
-from ..core.logger import log
+from core.config import config
+from core.logger import log
 
 
 class GeminiError(Exception):

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -26,9 +26,14 @@ from aiohttp import web
 
 from . import database
 from .config import config
-from ..ai.gemini_integration import generate_daily_summary, generate_memory, generate_reply
-from ..ai.agents.response_decider import should_respond as agent_should_respond
-from ..save_parsing.save_parser import parse_hk_save, format_save_summary, generate_save_analysis, SaveDataError
+from ai.gemini_integration import generate_daily_summary, generate_memory, generate_reply
+from ai.agents.response_decider import should_respond as agent_should_respond
+from save_parsing.save_parser import (
+    parse_hk_save,
+    format_save_summary,
+    generate_save_analysis,
+    SaveDataError,
+)
 from .logger import log
 
 from .validation import (

--- a/src/save_parsing/save_parser.py
+++ b/src/save_parsing/save_parser.py
@@ -4,7 +4,8 @@ import json
 import io
 from typing import Dict, Any, Optional
 
-from ..core.logger import log
+from core.logger import log
+from ai.gemini_integration import generate_reply
 from .hollow_knight_decrypt import decrypt_hollow_knight_save
 
 
@@ -260,9 +261,7 @@ def format_save_summary(summary: Dict[str, Any]) -> str:
 def generate_save_analysis(summary: Dict[str, Any]) -> str:
     """Generate AI analysis of the save data."""
     try:
-        from ..ai.gemini_integration import generate_reply
-        
-        prompt = f"""You are HollowBot, a seasoned Hollow Knight player who's 112% the game. 
+        prompt = f"""You are HollowBot, a seasoned Hollow Knight player who's 112% the game.
 Analyze this save data and give a short, personalized response (1-2 sentences max):
 
 Playtime: {summary['playtime_hours']} hours

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4,11 +4,6 @@
 import os
 import sys
 
-# Add the project root to Python path
-project_root = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, project_root)
-sys.path.insert(0, os.path.join(project_root, 'src'))
-
 def test_imports():
     """Test that all modules can be imported."""
     print("Testing imports...")
@@ -17,35 +12,35 @@ def test_imports():
     os.environ["GEMINI_API_KEY"] = "dummy"
 
     try:
-        from src.core import config
+        from core import config
         print("✅ config imported")
     except Exception as e:
         print(f"❌ config import failed: {e}")
         return False
     
     try:
-        from src.core import logger
+        from core import logger
         print("✅ logger imported")
     except Exception as e:
         print(f"❌ logger import failed: {e}")
         return False
     
     try:
-        from src.core import validation
+        from core import validation
         print("✅ validation imported")
     except Exception as e:
         print(f"❌ validation import failed: {e}")
         return False
     
     try:
-        from src.core import database
+        from core import database
         print("✅ database imported")
     except Exception as e:
         print(f"❌ database import failed: {e}")
         return False
     
     try:
-        from src.ai import gemini_integration
+        from ai import gemini_integration
         print("✅ gemini_integration imported")
     except Exception as e:
         print(f"❌ gemini_integration import failed: {e}")
@@ -70,7 +65,7 @@ def test_config():
     os.environ["GEMINI_API_KEY"] = "dummy-key-for-testing"
     
     try:
-        from src.core import config
+        from core import config
         print("✅ Configuration loaded successfully")
         print(f"   Discord token: {'*' * 10}")
         print(f"   Gemini API key: {'dummy' if config.config.google_api_key == 'dummy-key-for-testing' else 'real'}")
@@ -84,7 +79,7 @@ def test_validation():
     print("\nTesting validation...")
     
     try:
-        from src.core.validation import (
+        from core.validation import (
             validate_progress_text,
             validate_time_format,
             validate_custom_context,
@@ -132,7 +127,7 @@ def test_memory_db():
     """Test memory database operations."""
     print("\nTesting memory DB...")
     try:
-        from src.core import database
+        from core import database
 
         mem_id = database.add_memory(1, "Test memory")
         memories = database.get_memories_by_guild(1)
@@ -148,7 +143,7 @@ def test_leaderboard_db():
     """Test leaderboard database operations."""
     print("\nTesting leaderboard DB...")
     try:
-        from src.core import database
+        from core import database
         import time
 
         # Add some test progress data
@@ -182,7 +177,7 @@ def test_command_structure():
     """Test that the new command structure is properly defined."""
     print("\nTesting command structure...")
     try:
-        from src.core import main
+        from core import main
         
         # Check that BOT_VERSION is updated
         assert main.BOT_VERSION == "1.9", f"Expected BOT_VERSION 1.9, got {main.BOT_VERSION}"

--- a/tests/test_save_parser.py
+++ b/tests/test_save_parser.py
@@ -3,11 +3,20 @@
 import pytest
 import json
 import os
-import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from src.save_parsing.save_parser import parse_hk_save, format_save_summary, generate_save_analysis, SaveDataError
-from src.save_parsing.hollow_knight_decrypt import decrypt_hollow_knight_save, HollowKnightDecryptor
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+os.environ.setdefault("GEMINI_API_KEY", "dummy")
+
+from save_parsing.save_parser import (
+    parse_hk_save,
+    format_save_summary,
+    generate_save_analysis,
+    SaveDataError,
+)
+from save_parsing.hollow_knight_decrypt import (
+    decrypt_hollow_knight_save,
+    HollowKnightDecryptor,
+)
 
 
 class TestHollowKnightDecryption:


### PR DESCRIPTION
## Summary
- treat `src/` as package root via `pyproject.toml`
- move Gemini helper import to module scope and switch to absolute package imports
- drop `sys.path` hacks in main entrypoint and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c273f0cb808321b66104e452c9aa99