### PR TITLE
Add comprehensive slash command tests

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,246 +3,129 @@
 
 import os
 import sys
+import pytest
 
 # Add the src directory to the Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
+
 def test_imports():
     """Test that all modules can be imported."""
-    print("Testing imports...")
-
     os.environ["DISCORD_TOKEN"] = "dummy"
     os.environ["GEMINI_API_KEY"] = "dummy"
 
-    try:
-        from core import config
-        print("✅ config imported")
-    except Exception as e:
-        print(f"❌ config import failed: {e}")
-        return False
-    
-    try:
-        from core import logger
-        print("✅ logger imported")
-    except Exception as e:
-        print(f"❌ logger import failed: {e}")
-        return False
-    
-    try:
-        from core import validation
-        print("✅ validation imported")
-    except Exception as e:
-        print(f"❌ validation import failed: {e}")
-        return False
-    
-    try:
-        from core import database
-        print("✅ database imported")
-    except Exception as e:
-        print(f"❌ database import failed: {e}")
-        return False
-    
-    try:
-        from ai import gemini_integration
-        print("✅ gemini_integration imported")
-    except Exception as e:
-        print(f"❌ gemini_integration import failed: {e}")
-        return False
-    
-    try:
-        from langchain.chains import ConversationChain
-        from langchain.memory import ConversationBufferMemory
-        print("✅ langchain imported")
-    except Exception as e:
-        print(f"❌ langchain import failed: {e}")
-        return False
-    
-    return True
+    from core import config, logger, validation, database
+    from ai import gemini_integration
+    from langchain.chains import ConversationChain
+    from langchain.memory import ConversationBufferMemory
+
+    assert config is not None
+    assert logger is not None
+    assert validation is not None
+    assert database is not None
+    assert gemini_integration is not None
+    assert ConversationChain is not None and ConversationBufferMemory is not None
+
 
 def test_config():
     """Test configuration loading."""
-    print("\nTesting configuration...")
-    
-    # Set dummy environment variables for testing
     os.environ["DISCORD_TOKEN"] = "dummy-discord-token"
     os.environ["GEMINI_API_KEY"] = "dummy-key-for-testing"
-    
-    try:
-        from core import config
-        print("✅ Configuration loaded successfully")
-        print(f"   Discord token: {'*' * 10}")
-        print(f"   Gemini API key: {'dummy' if config.config.google_api_key == 'dummy-key-for-testing' else 'real'}")
-        return True
-    except Exception as e:
-        print(f"❌ Configuration failed: {e}")
-        return False
+
+    import importlib
+    from core import config as config_module
+    importlib.reload(config_module)
+
+    assert config_module.config.discord_token == "dummy-discord-token"
+    assert config_module.config.google_api_key == "dummy-key-for-testing"
+
 
 def test_validation():
     """Test validation functions."""
-    print("\nTesting validation...")
-    
-    try:
-        from core.validation import (
-            validate_progress_text,
-            validate_time_format,
-            validate_custom_context,
-        )
+    from core.validation import (
+        validate_progress_text,
+        validate_time_format,
+        validate_custom_context,
+        ValidationError,
+    )
 
-        # Test valid inputs
-        result = validate_progress_text("Beat the Mantis Lords!")
-        print(f"✅ Valid progress text: {result}")
+    # Test valid inputs
+    assert validate_progress_text("Beat the Mantis Lords!")
+    assert validate_time_format("18:30") == "18:30"
+    assert validate_custom_context("Speak like Zote") == "Speak like Zote"
 
-        result = validate_time_format("18:30")
-        print(f"✅ Valid time format: {result}")
-
-        result = validate_custom_context("Speak like Zote")
-        print(f"✅ Valid custom context: {result}")
-
-        # Test invalid inputs
-        try:
-            validate_progress_text("")
-            print("❌ Should have failed on empty text")
-            return False
-        except:
-            print("✅ Correctly rejected empty text")
-
-        try:
-            validate_time_format("25:00")
-            print("❌ Should have failed on invalid time")
-            return False
-        except:
-            print("✅ Correctly rejected invalid time")
-
-        try:
-            validate_custom_context("")
-            print("❌ Should have failed on empty context")
-            return False
-        except:
-            print("✅ Correctly rejected empty context")
-
-        return True
-    except Exception as e:
-        print(f"❌ Validation test failed: {e}")
-        return False
+    # Test invalid inputs
+    with pytest.raises(ValidationError):
+        validate_progress_text("")
+    with pytest.raises(ValidationError):
+        validate_time_format("25:00")
+    with pytest.raises(ValidationError):
+        validate_custom_context("")
 
 
 def test_memory_db():
     """Test memory database operations."""
-    print("\nTesting memory DB...")
-    try:
-        from core import database
+    from core import database
 
-        mem_id = database.add_memory(1, "Test memory")
-        memories = database.get_memories_by_guild(1)
-        assert any(mid == mem_id for mid, _ in memories)
-        database.delete_memory(1, mem_id)
-        print("✅ Memory DB functions")
-        return True
-    except Exception as e:
-        print(f"❌ Memory DB test failed: {e}")
-        return False
+    mem_id = database.add_memory(1, "Test memory")
+    memories = database.get_memories_by_guild(1)
+    assert any(mid == mem_id for mid, _ in memories)
+    database.delete_memory(1, mem_id)
+
 
 def test_leaderboard_db():
     """Test leaderboard database operations."""
-    print("\nTesting leaderboard DB...")
-    try:
-        from core import database
-        import time
+    from core import database
+    import time
 
-        # Add some test progress data
-        test_guild_id = 999
-        test_user_id = 888
-        current_time = int(time.time())
-        
-        # Add multiple updates for the same user
-        database.add_update(test_guild_id, test_user_id, "Beat False Knight", current_time - 86400 * 3)  # 3 days ago
-        database.add_update(test_guild_id, test_user_id, "Beat Hornet", current_time - 86400 * 2)  # 2 days ago
-        database.add_update(test_guild_id, test_user_id, "Beat Mantis Lords", current_time - 86400)  # 1 day ago
-        database.add_update(test_guild_id, test_user_id, "Got Crystal Heart", current_time - 3600)  # 1 hour ago
+    test_guild_id = 999
+    test_user_id = 888
+    current_time = int(time.time())
 
-        # Test the leaderboard function
-        stats = database.get_user_stats(test_guild_id)
-        assert len(stats) > 0, "Should have at least one user in stats"
-        
-        user_id, total_updates, days_active, recent_updates, first_update_ts = stats[0]
-        assert user_id == str(test_user_id), f"Expected user {test_user_id}, got {user_id}"
-        assert total_updates >= 4, f"Expected at least 4 updates, got {total_updates}"
-        assert days_active >= 3, f"Expected at least 3 active days, got {days_active}"
-        assert recent_updates >= 1, f"Expected at least 1 recent update, got {recent_updates}"
-        
-        print("✅ Leaderboard DB functions")
-        return True
-    except Exception as e:
-        print(f"❌ Leaderboard DB test failed: {e}")
-        return False
+    database.add_update(test_guild_id, test_user_id, "Beat False Knight", current_time - 86400 * 3)
+    database.add_update(test_guild_id, test_user_id, "Beat Hornet", current_time - 86400 * 2)
+    database.add_update(test_guild_id, test_user_id, "Beat Mantis Lords", current_time - 86400)
+    database.add_update(test_guild_id, test_user_id, "Got Crystal Heart", current_time - 3600)
+
+    stats = database.get_user_stats(test_guild_id)
+    assert len(stats) > 0
+
+    user_id, total_updates, days_active, recent_updates, first_update_ts = stats[0]
+    assert user_id == str(test_user_id)
+    assert total_updates >= 4
+    assert days_active >= 3
+    assert recent_updates >= 1
+
 
 def test_command_structure():
     """Test that the new command structure is properly defined."""
-    print("\nTesting command structure...")
-    try:
-        from core import main
-        
-        # Check that BOT_VERSION is updated
-        assert main.BOT_VERSION == "2.3", f"Expected BOT_VERSION 2.3, got {main.BOT_VERSION}"
-        print(f"✅ Bot version: {main.BOT_VERSION}")
-        
-        # Check that the bot object exists and has the right structure
-        assert hasattr(main, 'bot'), "Bot object should exist"
-        assert hasattr(main, 'hollow_group'), "hollow_group should exist"
-        
-        print("✅ Command structure is properly defined")
-        return True
-    except Exception as e:
-        print(f"❌ Command structure test failed: {e}")
-        return False
+    from core import main
+
+    assert main.BOT_VERSION == "2.3"
+    assert hasattr(main, 'bot')
+    assert hasattr(main, 'hollow_group')
+
 
 def test_leaderboard_algorithm():
     """Test the leaderboard scoring algorithm."""
-    print("\nTesting leaderboard algorithm...")
-    try:
-        import time
-        
-        # Simulate the scoring algorithm from the leaderboard command
-        def calculate_score(user_id: str, total_updates: int, days_active: int, recent_updates: int, first_update_ts: int) -> float:
-            """Calculate a combined score for the leaderboard."""
-            # Base score from total updates (most important)
-            base_score = total_updates * 10
-            
-            # Consistency bonus (days active vs total days since first update)
-            days_since_first = (int(time.time()) - first_update_ts) // 86400
-            if days_since_first > 0:
-                consistency = (days_active / days_since_first) * 5
-            else:
-                consistency = 0
-            
-            # Recent activity bonus (updates in last 7 days)
-            recent_bonus = recent_updates * 3
-            
-            # Longevity bonus (longer active = more points)
-            longevity = min(days_active * 0.5, 20)  # Cap at 20 points
-            
-            return base_score + consistency + recent_bonus + longevity
+    import time
 
-        # Test with sample data
-        current_time = int(time.time())
-        
-        # User with more updates should score higher
-        score1 = calculate_score("user1", 10, 5, 2, current_time - 86400 * 7)  # 10 updates, 5 days active
-        score2 = calculate_score("user2", 5, 3, 1, current_time - 86400 * 5)   # 5 updates, 3 days active
-        
-        assert score1 > score2, f"User with more updates should score higher: {score1} vs {score2}"
-        
-        # User with recent activity should get bonus
-        score3 = calculate_score("user3", 5, 2, 3, current_time - 86400 * 3)   # 5 updates, 3 recent
-        score4 = calculate_score("user4", 5, 2, 0, current_time - 86400 * 3)   # 5 updates, 0 recent
-        
-        assert score3 > score4, f"User with recent activity should score higher: {score3} vs {score4}"
-        
-        print("✅ Leaderboard algorithm works correctly")
-        return True
-    except Exception as e:
-        print(f"❌ Leaderboard algorithm test failed: {e}")
-        return False
+    def calculate_score(user_id: str, total_updates: int, days_active: int, recent_updates: int, first_update_ts: int) -> float:
+        base_score = total_updates * 10
+        days_since_first = (int(time.time()) - first_update_ts) // 86400
+        consistency = (days_active / days_since_first) * 5 if days_since_first > 0 else 0
+        recent_bonus = recent_updates * 3
+        longevity = min(days_active * 0.5, 20)
+        return base_score + consistency + recent_bonus + longevity
+
+    current_time = int(time.time())
+    score1 = calculate_score("user1", 10, 5, 2, current_time - 86400 * 7)
+    score2 = calculate_score("user2", 5, 3, 1, current_time - 86400 * 5)
+    assert score1 > score2
+
+    score3 = calculate_score("user3", 5, 2, 3, current_time - 86400 * 3)
+    score4 = calculate_score("user4", 5, 2, 0, current_time - 86400 * 3)
+    assert score3 > score4
 def main():
     """Run all tests."""
     print("🧪 Hollow Knight Bot Test Suite")

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import time
+import pytest
 
 # Add the src directory to the Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
@@ -12,9 +13,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 os.environ["DISCORD_TOKEN"] = "dummy"
 os.environ["GEMINI_API_KEY"] = "dummy-key-for-testing"
 
+
 def test_progress_formatting_with_none_values():
     """Test that progress data formatting handles None values correctly."""
-    print("Testing progress formatting with None values...")
     
     # Sample data with None values (this is what was causing the error)
     sample_data = {
@@ -34,41 +35,35 @@ def test_progress_formatting_with_none_values():
         'ts': int(time.time()) - 3600,
     }
     
-    try:
-        # Test the formatting logic that was failing
-        completion = sample_data['completion_percent']
-        playtime = sample_data['playtime_hours']
-        geo = sample_data['geo']
-        health = sample_data['health']
-        max_health = sample_data['max_health']
-        deaths = sample_data['deaths']
-        scene = sample_data['scene']
-        zone = sample_data['zone']
-        nail_upgrades = sample_data['nail_upgrades']
-        soul_vessels = sample_data['soul_vessels']
-        mask_shards = sample_data['mask_shards']
-        charms_owned = sample_data['charms_owned']
-        bosses_defeated = sample_data['bosses_defeated']
-        
-        # This is the formatting logic from the fixed code
-        message = f"🎮 **Progress**: {completion or 0}% complete\n"
-        message += f"⏱️ **Playtime**: {(playtime if playtime is not None else 0):.2f} hours\n"
-        message += f"💰 **Geo**: {(geo if geo is not None else 0):,}\n"
-        message += f"❤️ **Health**: {health or 0}/{max_health or 0} hearts\n"
-        message += f"💀 **Deaths**: {deaths or 0}\n"
-        message += f"🗡️ **Nail**: +{nail_upgrades or 0} upgrades\n"
-        message += f"💙 **Soul**: {soul_vessels or 0} vessels\n"
-        message += f"🎭 **Charms**: {charms_owned or 0} owned\n"
-        message += f"👹 **Bosses**: {bosses_defeated or 0} defeated\n"
-        message += f"📍 **Location**: {scene or 'Unknown'} ({zone or 'Unknown'})"
-        
-        print("✅ Formatting with None values succeeded")
-        print(f"Generated message: {message}")
-        return True
-        
-    except Exception as e:
-        print(f"❌ Formatting with None values failed: {e}")
-        return False
+    # Test the formatting logic that was failing
+    completion = sample_data['completion_percent']
+    playtime = sample_data['playtime_hours']
+    geo = sample_data['geo']
+    health = sample_data['health']
+    max_health = sample_data['max_health']
+    deaths = sample_data['deaths']
+    scene = sample_data['scene']
+    zone = sample_data['zone']
+    nail_upgrades = sample_data['nail_upgrades']
+    soul_vessels = sample_data['soul_vessels']
+    mask_shards = sample_data['mask_shards']
+    charms_owned = sample_data['charms_owned']
+    bosses_defeated = sample_data['bosses_defeated']
+
+    message = f"🎮 **Progress**: {completion or 0}% complete\n"
+    message += f"⏱️ **Playtime**: {(playtime if playtime is not None else 0):.2f} hours\n"
+    message += f"💰 **Geo**: {(geo if geo is not None else 0):,}\n"
+    message += f"❤️ **Health**: {health or 0}/{max_health or 0} hearts\n"
+    message += f"💀 **Deaths**: {deaths or 0}\n"
+    message += f"🗡️ **Nail**: +{nail_upgrades or 0} upgrades\n"
+    message += f"💙 **Soul**: {soul_vessels or 0} vessels\n"
+    message += f"🎭 **Charms**: {charms_owned or 0} owned\n"
+    message += f"👹 **Bosses**: {bosses_defeated or 0} defeated\n"
+    message += f"📍 **Location**: {scene or 'Unknown'} ({zone or 'Unknown'})"
+
+    assert "0% complete" in message
+    assert "0.00 hours" in message
+    assert "0/0 hearts" in message
 
 def test_progress_formatting_with_mixed_values():
     """Test formatting with mixed None and valid values."""
@@ -92,41 +87,34 @@ def test_progress_formatting_with_mixed_values():
         'ts': int(time.time()) - 3600,
     }
     
-    try:
-        # Test the formatting logic
-        completion = sample_data['completion_percent']
-        playtime = sample_data['playtime_hours']
-        geo = sample_data['geo']
-        health = sample_data['health']
-        max_health = sample_data['max_health']
-        deaths = sample_data['deaths']
-        scene = sample_data['scene']
-        zone = sample_data['zone']
-        nail_upgrades = sample_data['nail_upgrades']
-        soul_vessels = sample_data['soul_vessels']
-        mask_shards = sample_data['mask_shards']
-        charms_owned = sample_data['charms_owned']
-        bosses_defeated = sample_data['bosses_defeated']
-        
-        # This is the formatting logic from the fixed code
-        message = f"🎮 **Progress**: {completion or 0}% complete\n"
-        message += f"⏱️ **Playtime**: {(playtime if playtime is not None else 0):.2f} hours\n"
-        message += f"💰 **Geo**: {(geo if geo is not None else 0):,}\n"
-        message += f"❤️ **Health**: {health or 0}/{max_health or 0} hearts\n"
-        message += f"💀 **Deaths**: {deaths or 0}\n"
-        message += f"🗡️ **Nail**: +{nail_upgrades or 0} upgrades\n"
-        message += f"💙 **Soul**: {soul_vessels or 0} vessels\n"
-        message += f"🎭 **Charms**: {charms_owned or 0} owned\n"
-        message += f"👹 **Bosses**: {bosses_defeated or 0} defeated\n"
-        message += f"📍 **Location**: {scene or 'Unknown'} ({zone or 'Unknown'})"
-        
-        print("✅ Formatting with mixed values succeeded")
-        print(f"Generated message: {message}")
-        return True
-        
-    except Exception as e:
-        print(f"❌ Formatting with mixed values failed: {e}")
-        return False
+    # Test the formatting logic
+    completion = sample_data['completion_percent']
+    playtime = sample_data['playtime_hours']
+    geo = sample_data['geo']
+    health = sample_data['health']
+    max_health = sample_data['max_health']
+    deaths = sample_data['deaths']
+    scene = sample_data['scene']
+    zone = sample_data['zone']
+    nail_upgrades = sample_data['nail_upgrades']
+    soul_vessels = sample_data['soul_vessels']
+    mask_shards = sample_data['mask_shards']
+    charms_owned = sample_data['charms_owned']
+    bosses_defeated = sample_data['bosses_defeated']
+
+    message = f"🎮 **Progress**: {completion or 0}% complete\n"
+    message += f"⏱️ **Playtime**: {(playtime if playtime is not None else 0):.2f} hours\n"
+    message += f"💰 **Geo**: {(geo if geo is not None else 0):,}\n"
+    message += f"❤️ **Health**: {health or 0}/{max_health or 0} hearts\n"
+    message += f"💀 **Deaths**: {deaths or 0}\n"
+    message += f"🗡️ **Nail**: +{nail_upgrades or 0} upgrades\n"
+    message += f"💙 **Soul**: {soul_vessels or 0} vessels\n"
+    message += f"🎭 **Charms**: {charms_owned or 0} owned\n"
+    message += f"👹 **Bosses**: {bosses_defeated or 0} defeated\n"
+    message += f"📍 **Location**: {scene or 'Unknown'} ({zone or 'Unknown'})"
+
+    assert "10.50 hours" in message
+    assert "Unknown" in message
 
 def test_history_formatting_with_none_values():
     """Test history formatting with None values."""
@@ -146,23 +134,18 @@ def test_history_formatting_with_none_values():
         'ts': int(time.time()) - 3600,
     }
     
-    try:
-        # This is the history formatting logic from the fixed code
-        message = f"🎮 {save['completion_percent'] or 0}% complete | ⏱️ {(save['playtime_hours'] if save['playtime_hours'] is not None else 0):.1f}h | 💰 {(save['geo'] if save['geo'] is not None else 0):,} geo\n"
-        message += f"❤️ {save['health'] or 0}/{save['max_health'] or 0} hearts | 💀 {save['deaths'] or 0} deaths | 👹 {save['bosses_defeated'] or 0} bosses\n"
-        message += f"📍 {save['scene'] or 'Unknown'} ({save['zone'] or 'Unknown'})"
-        
-        print("✅ History formatting with None values succeeded")
-        print(f"Generated message: {message}")
-        return True
-        
-    except Exception as e:
-        print(f"❌ History formatting with None values failed: {e}")
-        return False
+    message = (
+        f"🎮 {save['completion_percent'] or 0}% complete | ⏱️ {(save['playtime_hours'] if save['playtime_hours'] is not None else 0):.1f}h | 💰 {(save['geo'] if save['geo'] is not None else 0):,} geo\n"
+    )
+    message += f"❤️ {save['health'] or 0}/{save['max_health'] or 0} hearts | 💀 {save['deaths'] or 0} deaths | 👹 {save['bosses_defeated'] or 0} bosses\n"
+    message += f"📍 {save['scene'] or 'Unknown'} ({save['zone'] or 'Unknown'})"
+
+    assert "0% complete" in message
+    assert "0.0h" in message
+    assert "Unknown" in message
 
 def test_old_formatting_logic_fails():
     """Test that the old formatting logic would fail with None values."""
-    print("Testing that old formatting logic fails with None values...")
     
     # Sample data with None values
     sample_data = {
@@ -177,31 +160,23 @@ def test_old_formatting_logic_fails():
         'ts': int(time.time()) - 3600,
     }
     
-    try:
-        # This is the OLD formatting logic that would fail
-        completion = sample_data['completion_percent']
-        playtime = sample_data['playtime_hours']
-        geo = sample_data['geo']
-        health = sample_data['health']
-        max_health = sample_data['max_health']
-        deaths = sample_data['deaths']
-        scene = sample_data['scene']
-        zone = sample_data['zone']
-        
-        # OLD logic that would cause the error
+    # This is the OLD formatting logic that would fail
+    completion = sample_data['completion_percent']
+    playtime = sample_data['playtime_hours']
+    geo = sample_data['geo']
+    health = sample_data['health']
+    max_health = sample_data['max_health']
+    deaths = sample_data['deaths']
+    scene = sample_data['scene']
+    zone = sample_data['zone']
+
+    with pytest.raises(Exception):
         message = f"🎮 **Progress**: {completion}% complete\n"
-        message += f"⏱️ **Playtime**: {playtime:.2f} hours\n"  # This would fail!
-        message += f"💰 **Geo**: {geo:,}\n"  # This would fail!
+        message += f"⏱️ **Playtime**: {playtime:.2f} hours\n"  # This should fail
+        message += f"💰 **Geo**: {geo:,}\n"  # This should fail
         message += f"❤️ **Health**: {health}/{max_health} hearts\n"
         message += f"💀 **Deaths**: {deaths}\n"
         message += f"📍 **Location**: {scene} ({zone})"
-        
-        print("❌ Old formatting logic should have failed but didn't")
-        return False
-        
-    except Exception as e:
-        print(f"✅ Old formatting logic correctly failed: {e}")
-        return True
 
 def main():
     """Run all formatting tests."""

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -23,6 +23,7 @@ class TestSlashCommands:
         self.mock_guild = Mock()
         self.mock_guild.id = 123456789
         self.mock_guild.name = "Test Guild"
+        self.mock_guild.get_member = Mock(return_value=None)
         
         self.mock_user = Mock()
         self.mock_user.id = 987654321
@@ -33,7 +34,11 @@ class TestSlashCommands:
         self.mock_interaction.user = self.mock_user
         self.mock_interaction.response = Mock()
         self.mock_interaction.response.is_done.return_value = False
+        self.mock_interaction.response.send_message = AsyncMock()
         self.mock_interaction.followup = Mock()
+        self.mock_interaction.followup.send = AsyncMock()
+        self.mock_interaction.channel = Mock()
+        self.mock_interaction.channel.send = AsyncMock()
         
         # Mock database responses
         self.sample_progress_data = [
@@ -81,8 +86,8 @@ class TestSlashCommands:
         ]
 
     @patch('core.database.get_player_progress_history')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
     def test_slash_progress_check_with_valid_data(self, mock_validate_user, mock_validate_guild, mock_get_progress):
         """Test slash_progress_check with valid data."""
         from core.main import slash_progress_check
@@ -108,8 +113,8 @@ class TestSlashCommands:
         assert "Crossroads" in message
 
     @patch('core.database.get_player_progress_history')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
     def test_slash_progress_check_with_none_values(self, mock_validate_user, mock_validate_guild, mock_get_progress):
         """Test slash_progress_check with None values to catch formatting errors."""
         from core.main import slash_progress_check
@@ -119,7 +124,7 @@ class TestSlashCommands:
         
         # This should not raise a formatting error
         import asyncio
-        asyncio.run(slash_progress_check(self.mock_interaction, limit=1, history=False))
+        asyncio.run(slash_progress_check.callback(self.mock_interaction, limit=1, history=False))
         
         # Verify interaction was called
         self.mock_interaction.response.send_message.assert_called_once()
@@ -133,8 +138,8 @@ class TestSlashCommands:
         assert "Unknown" in message  # scene/zone should be "Unknown"
 
     @patch('core.database.get_player_progress_history')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
     def test_slash_progress_check_history_with_none_values(self, mock_validate_user, mock_validate_guild, mock_get_progress):
         """Test slash_progress_check history mode with None values."""
         from core.main import slash_progress_check
@@ -144,7 +149,7 @@ class TestSlashCommands:
         
         # This should not raise a formatting error
         import asyncio
-        asyncio.run(slash_progress_check(self.mock_interaction, limit=1, history=True))
+        asyncio.run(slash_progress_check.callback(self.mock_interaction, limit=1, history=True))
         
         # Verify interaction was called
         self.mock_interaction.response.send_message.assert_called_once()
@@ -158,8 +163,8 @@ class TestSlashCommands:
         assert "Unknown" in message
 
     @patch('core.database.get_player_progress_history')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
     def test_slash_progress_check_no_data(self, mock_validate_user, mock_validate_guild, mock_get_progress):
         """Test slash_progress_check when no data exists."""
         from core.main import slash_progress_check
@@ -168,7 +173,7 @@ class TestSlashCommands:
         mock_get_progress.return_value = []
         
         import asyncio
-        asyncio.run(slash_progress_check(self.mock_interaction, limit=1, history=False))
+        asyncio.run(slash_progress_check.callback(self.mock_interaction, limit=1, history=False))
         
         # Verify interaction was called with no data message
         self.mock_interaction.response.send_message.assert_called_once()
@@ -178,15 +183,15 @@ class TestSlashCommands:
         assert "TestUser" in message
 
     @patch('core.database.get_player_progress_history')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
     def test_slash_progress_check_invalid_limit(self, mock_validate_user, mock_validate_guild, mock_get_progress):
         """Test slash_progress_check with invalid limit values."""
         from core.main import slash_progress_check
         
         # Test limit too high
         import asyncio
-        asyncio.run(slash_progress_check(self.mock_interaction, limit=25, history=False))
+        asyncio.run(slash_progress_check.callback(self.mock_interaction, limit=25, history=False))
         
         # Should send error message
         self.mock_interaction.response.send_message.assert_called_once()
@@ -204,7 +209,7 @@ class TestSlashCommands:
         self.mock_interaction.guild = None
         
         import asyncio
-        asyncio.run(slash_progress_check(self.mock_interaction, limit=1, history=False))
+        asyncio.run(slash_progress_check.callback(self.mock_interaction, limit=1, history=False))
         
         # Should send error message
         self.mock_interaction.response.send_message.assert_called_once()
@@ -213,9 +218,9 @@ class TestSlashCommands:
 
     @patch('core.database.add_update')
     @patch('core.database.get_last_update')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
-    @patch('core.validation.validate_progress_text')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
+    @patch('core.main.validate_progress_text')
     @patch('core.main._build_progress_reply')
     def test_slash_record_valid_input(self, mock_build_reply, mock_validate_text, mock_validate_user, 
                                     mock_validate_guild, mock_get_last, mock_add_update):
@@ -228,7 +233,7 @@ class TestSlashCommands:
         mock_build_reply.return_value = "Nice work, gamer!"
         
         import asyncio
-        asyncio.run(slash_record(self.mock_interaction, "Beat the Mantis Lords"))
+        asyncio.run(slash_record.callback(self.mock_interaction, "Beat the Mantis Lords"))
         
         # Verify database was called
         mock_add_update.assert_called_once()
@@ -241,9 +246,9 @@ class TestSlashCommands:
 
     @patch('core.database.add_update')
     @patch('core.database.get_last_update')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
-    @patch('core.validation.validate_progress_text')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
+    @patch('core.main.validate_progress_text')
     @patch('core.main._build_progress_reply')
     def test_slash_record_validation_error(self, mock_build_reply, mock_validate_text, mock_validate_user, 
                                          mock_validate_guild, mock_get_last, mock_add_update):
@@ -255,7 +260,7 @@ class TestSlashCommands:
         mock_validate_text.side_effect = ValidationError("Invalid text")
         
         import asyncio
-        asyncio.run(slash_record(self.mock_interaction, ""))
+        asyncio.run(slash_record.callback(self.mock_interaction, ""))
         
         # Should send error message
         self.mock_interaction.response.send_message.assert_called_once()
@@ -264,9 +269,9 @@ class TestSlashCommands:
 
     @patch('core.database.add_update')
     @patch('core.database.get_last_update')
-    @patch('core.validation.validate_guild_id')
-    @patch('core.validation.validate_user_id')
-    @patch('core.validation.validate_progress_text')
+    @patch('core.main.validate_guild_id')
+    @patch('core.main.validate_user_id')
+    @patch('core.main.validate_progress_text')
     @patch('core.main._build_progress_reply')
     def test_slash_record_database_error(self, mock_build_reply, mock_validate_text, mock_validate_user, 
                                        mock_validate_guild, mock_get_last, mock_add_update):
@@ -279,7 +284,7 @@ class TestSlashCommands:
         mock_add_update.side_effect = DatabaseError("Database connection failed")
         
         import asyncio
-        asyncio.run(slash_record(self.mock_interaction, "Beat the Mantis Lords"))
+        asyncio.run(slash_record.callback(self.mock_interaction, "Beat the Mantis Lords"))
         
         # Should send error message
         self.mock_interaction.response.send_message.assert_called_once()
@@ -314,10 +319,10 @@ class TestSlashCommands:
         ]
         
         with patch('core.database.get_player_progress_history', return_value=mixed_data):
-            with patch('core.validation.validate_guild_id'):
-                with patch('core.validation.validate_user_id'):
+            with patch('core.main.validate_guild_id'):
+                with patch('core.main.validate_user_id'):
                     import asyncio
-                    asyncio.run(slash_progress_check(self.mock_interaction, limit=1, history=False))
+                    asyncio.run(slash_progress_check.callback(self.mock_interaction, limit=1, history=False))
                     
                     # Should not raise any formatting errors
                     self.mock_interaction.response.send_message.assert_called_once()
@@ -330,6 +335,48 @@ class TestSlashCommands:
                     assert "5/0 hearts" in message  # health: 5, max_health: None -> 0
                     assert "0" in message  # deaths: 0
                     assert "Unknown" in message  # empty scene -> Unknown
+
+    @patch('core.database.get_game_stats_leaderboard')
+    def test_slash_leaderboard_with_data(self, mock_get_stats):
+        """Test slash_leaderboard with sample data."""
+        from core.main import slash_leaderboard
+
+        mock_get_stats.return_value = [
+            (111, 80.0, 50.0, 10, 1000, 5, 3, 20)
+        ]
+
+        import asyncio
+        asyncio.run(slash_leaderboard.callback(self.mock_interaction))
+
+        self.mock_interaction.response.send_message.assert_called_once()
+        message = self.mock_interaction.response.send_message.call_args[0][0]
+        assert "Hallownest Game Stats Leaderboard" in message
+        assert "User 111" in message
+
+    @patch('core.database.get_game_stats_leaderboard')
+    def test_slash_leaderboard_no_data(self, mock_get_stats):
+        """Test slash_leaderboard when no stats are available."""
+        from core.main import slash_leaderboard
+
+        mock_get_stats.return_value = []
+
+        import asyncio
+        asyncio.run(slash_leaderboard.callback(self.mock_interaction))
+
+        self.mock_interaction.response.send_message.assert_called_once()
+        message = self.mock_interaction.response.send_message.call_args[0][0]
+        assert "No gamers have uploaded save data" in message
+
+    def test_slash_info(self):
+        """Test slash_info outputs bot version info."""
+        from core.main import slash_info, BOT_VERSION
+
+        import asyncio
+        asyncio.run(slash_info.callback(self.mock_interaction))
+
+        self.mock_interaction.response.send_message.assert_called_once()
+        message = self.mock_interaction.response.send_message.call_args[0][0]
+        assert f"HollowBot v{BOT_VERSION}" in message
 
 
 def run_tests():

--- a/tests/test_slash_commands_simple.py
+++ b/tests/test_slash_commands_simple.py
@@ -12,9 +12,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 os.environ["DISCORD_TOKEN"] = "dummy"
 os.environ["GEMINI_API_KEY"] = "dummy-key-for-testing"
 
+
 def test_progress_message_generation():
     """Test the core logic for generating progress messages."""
-    print("Testing progress message generation...")
     
     # Test data with None values (the original issue)
     sample_data = {
@@ -34,46 +34,41 @@ def test_progress_message_generation():
         'ts': int(time.time()) - 3600,
     }
     
-    try:
-        # Extract values (this is what the slash command does)
-        completion = sample_data['completion_percent']
-        playtime = sample_data['playtime_hours']
-        geo = sample_data['geo']
-        health = sample_data['health']
-        max_health = sample_data['max_health']
-        deaths = sample_data['deaths']
-        scene = sample_data['scene']
-        zone = sample_data['zone']
-        nail_upgrades = sample_data['nail_upgrades']
-        soul_vessels = sample_data['soul_vessels']
-        mask_shards = sample_data['mask_shards']
-        charms_owned = sample_data['charms_owned']
-        bosses_defeated = sample_data['bosses_defeated']
-        
-        # Generate the message (this is the fixed formatting logic)
-        message = f"📜 **Latest Save Data for TestUser** (1h ago)\n\n"
-        message += f"🎮 **Progress**: {completion or 0}% complete\n"
-        message += f"⏱️ **Playtime**: {(playtime if playtime is not None else 0):.2f} hours\n"
-        message += f"💰 **Geo**: {(geo if geo is not None else 0):,}\n"
-        message += f"❤️ **Health**: {health or 0}/{max_health or 0} hearts\n"
-        message += f"💀 **Deaths**: {deaths or 0}\n"
-        message += f"🗡️ **Nail**: +{nail_upgrades or 0} upgrades\n"
-        message += f"💙 **Soul**: {soul_vessels or 0} vessels\n"
-        message += f"🎭 **Charms**: {charms_owned or 0} owned\n"
-        message += f"👹 **Bosses**: {bosses_defeated or 0} defeated\n"
-        message += f"📍 **Location**: {scene or 'Unknown'} ({zone or 'Unknown'})"
-        
-        print("✅ Progress message generation succeeded")
-        print(f"Generated message length: {len(message)} characters")
-        return True
-        
-    except Exception as e:
-        print(f"❌ Progress message generation failed: {e}")
-        return False
+    # Extract values (this is what the slash command does)
+    completion = sample_data['completion_percent']
+    playtime = sample_data['playtime_hours']
+    geo = sample_data['geo']
+    health = sample_data['health']
+    max_health = sample_data['max_health']
+    deaths = sample_data['deaths']
+    scene = sample_data['scene']
+    zone = sample_data['zone']
+    nail_upgrades = sample_data['nail_upgrades']
+    soul_vessels = sample_data['soul_vessels']
+    mask_shards = sample_data['mask_shards']
+    charms_owned = sample_data['charms_owned']
+    bosses_defeated = sample_data['bosses_defeated']
+
+    # Generate the message (this is the fixed formatting logic)
+    message = f"📜 **Latest Save Data for TestUser** (1h ago)\n\n"
+    message += f"🎮 **Progress**: {completion or 0}% complete\n"
+    message += f"⏱️ **Playtime**: {(playtime if playtime is not None else 0):.2f} hours\n"
+    message += f"💰 **Geo**: {(geo if geo is not None else 0):,}\n"
+    message += f"❤️ **Health**: {health or 0}/{max_health or 0} hearts\n"
+    message += f"💀 **Deaths**: {deaths or 0}\n"
+    message += f"🗡️ **Nail**: +{nail_upgrades or 0} upgrades\n"
+    message += f"💙 **Soul**: {soul_vessels or 0} vessels\n"
+    message += f"🎭 **Charms**: {charms_owned or 0} owned\n"
+    message += f"👹 **Bosses**: {bosses_defeated or 0} defeated\n"
+    message += f"📍 **Location**: {scene or 'Unknown'} ({zone or 'Unknown'})"
+
+    assert "0% complete" in message
+    assert "0.00 hours" in message
+    assert "0/0 hearts" in message
+    assert "Unknown" in message
 
 def test_history_message_generation():
     """Test the core logic for generating history messages."""
-    print("Testing history message generation...")
     
     # Test data for history format
     save = {
@@ -89,24 +84,18 @@ def test_history_message_generation():
         'ts': int(time.time()) - 3600,
     }
     
-    try:
-        # Generate history message (this is the fixed formatting logic)
-        message = f"**#1** (1h ago)\n"
-        message += f"🎮 {save['completion_percent'] or 0}% complete | ⏱️ {(save['playtime_hours'] if save['playtime_hours'] is not None else 0):.1f}h | 💰 {(save['geo'] if save['geo'] is not None else 0):,} geo\n"
-        message += f"❤️ {save['health'] or 0}/{save['max_health'] or 0} hearts | 💀 {save['deaths'] or 0} deaths | 👹 {save['bosses_defeated'] or 0} bosses\n"
-        message += f"📍 {save['scene'] or 'Unknown'} ({save['zone'] or 'Unknown'})\n\n"
-        
-        print("✅ History message generation succeeded")
-        print(f"Generated message length: {len(message)} characters")
-        return True
-        
-    except Exception as e:
-        print(f"❌ History message generation failed: {e}")
-        return False
+    # Generate history message (this is the fixed formatting logic)
+    message = f"**#1** (1h ago)\n"
+    message += f"🎮 {save['completion_percent'] or 0}% complete | ⏱️ {(save['playtime_hours'] if save['playtime_hours'] is not None else 0):.1f}h | 💰 {(save['geo'] if save['geo'] is not None else 0):,} geo\n"
+    message += f"❤️ {save['health'] or 0}/{save['max_health'] or 0} hearts | 💀 {save['deaths'] or 0} deaths | 👹 {save['bosses_defeated'] or 0} bosses\n"
+    message += f"📍 {save['scene'] or 'Unknown'} ({save['zone'] or 'Unknown'})\n\n"
+
+    assert "0% complete" in message
+    assert "0.0h" in message
+    assert "0/0 hearts" in message
 
 def test_mixed_data_scenarios():
     """Test various combinations of None and valid data."""
-    print("Testing mixed data scenarios...")
     
     test_cases = [
         {
@@ -151,52 +140,31 @@ def test_mixed_data_scenarios():
     ]
     
     for test_case in test_cases:
-        try:
-            data = test_case['data']
-            
-            # Test the formatting logic
-            message = f"🎮 **Progress**: {data['completion_percent'] or 0}% complete\n"
-            message += f"⏱️ **Playtime**: {(data['playtime_hours'] if data['playtime_hours'] is not None else 0):.2f} hours\n"
-            message += f"💰 **Geo**: {(data['geo'] if data['geo'] is not None else 0):,}\n"
-            message += f"❤️ **Health**: {data['health'] or 0}/{data['max_health'] or 0} hearts\n"
-            message += f"💀 **Deaths**: {data['deaths'] or 0}\n"
-            message += f"📍 **Location**: {data['scene'] or 'Unknown'} ({data['zone'] or 'Unknown'})"
-            
-            print(f"✅ {test_case['name']} - formatting succeeded")
-            
-        except Exception as e:
-            print(f"❌ {test_case['name']} - formatting failed: {e}")
-            return False
-    
-    return True
+        data = test_case['data']
+        message = f"🎮 **Progress**: {data['completion_percent'] or 0}% complete\n"
+        message += f"⏱️ **Playtime**: {(data['playtime_hours'] if data['playtime_hours'] is not None else 0):.2f} hours\n"
+        message += f"💰 **Geo**: {(data['geo'] if data['geo'] is not None else 0):,}\n"
+        message += f"❤️ **Health**: {data['health'] or 0}/{data['max_health'] or 0} hearts\n"
+        message += f"💀 **Deaths**: {data['deaths'] or 0}\n"
+        message += f"📍 **Location**: {data['scene'] or 'Unknown'} ({data['zone'] or 'Unknown'})"
+        assert isinstance(message, str)
 
 def test_database_integration():
     """Test that database functions work with the new schema."""
-    print("Testing database integration...")
-    
-    try:
-        from core import database
-        
-        # Test that we can add an update (this was the original issue)
-        test_guild_id = 999999
-        test_user_id = 888888
-        test_text = "Test progress update"
-        test_ts = int(time.time())
-        
-        # This should work with the new schema
-        database.add_update(test_guild_id, test_user_id, test_text, test_ts)
-        
-        # Verify it was added
-        last_update = database.get_last_update(test_guild_id, test_user_id)
-        assert last_update is not None, "Update should have been added"
-        assert last_update[0] == test_text, "Update text should match"
-        
-        print("✅ Database integration succeeded")
-        return True
-        
-    except Exception as e:
-        print(f"❌ Database integration failed: {e}")
-        return False
+    from core import database
+
+    # Test that we can add an update (this was the original issue)
+    test_guild_id = 999999
+    test_user_id = 888888
+    test_text = "Test progress update"
+    test_ts = int(time.time())
+
+    database.add_update(test_guild_id, test_user_id, test_text, test_ts)
+
+    # Verify it was added
+    last_update = database.get_last_update(test_guild_id, test_user_id)
+    assert last_update is not None
+    assert last_update[0] == test_text
 
 def main():
     """Run all simple slash command tests."""


### PR DESCRIPTION
## Summary
- fix slash command tests to call command callbacks
- convert legacy return-based tests to assertions
- add coverage for leaderboard and info commands

## Testing
- `pytest`
- `pytest --cov=src --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68c5ce3d12788321bc3386d2caa780ad