### PR TITLE
Add cryptography dependency for MySQL auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ langchain-community>=0.0.20,<1.0.0
 # Database support (for production PostgreSQL and MySQL)
 psycopg2-binary>=2.9.0,<3.0.0
 PyMySQL>=1.0.0,<2.0.0
+cryptography>=41.0.0
 
 # Timezone support
 pytz>=2023.3


### PR DESCRIPTION
## Summary
- add cryptography library to support PyMySQL caching_sha2_password authentication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d45dde2c8321a8f3b146f7fc54a7